### PR TITLE
Renames + abstract type

### DIFF
--- a/src/JuliaLibWrapping.jl
+++ b/src/JuliaLibWrapping.jl
@@ -4,10 +4,13 @@ using OrderedCollections: OrderedDict
 using Graphs: SimpleDiGraph, add_edge!, strongly_connected_components, topological_sort
 using JSON: JSON
 
-export import_abi_info, wrapper
-export CProject, ABIInfo
+export import_abi_info, write_wrapper
+export AbstractTarget, CTarget, ABIInfo
 
 include("abi_import.jl")
+
+abstract type AbstractTarget end
+
 include("c.jl")
 
 end

--- a/src/c.jl
+++ b/src/c.jl
@@ -1,4 +1,4 @@
-struct CProject
+struct CTarget <: AbstractTarget
     dir::String
     headerbase::String
 end
@@ -10,7 +10,7 @@ function unwrap_pointer_type(type_id::Int, typeinfo)
     return type_id
 end
 
-function wrapper(dest::CProject, abi_info::ABIInfo)
+function write_wrapper(dest::CTarget, abi_info::ABIInfo)
     (; entrypoints, typeinfo, forward_declared) = abi_info
 
     # Write the header file for C

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,12 +160,12 @@ end
         end
     end
 
-    @testset "C wrapper" begin
+    @testset "write_wrapper" begin
         mktempdir() do path
             mkpath(path)
-            dest = CProject(path, "libsimple")
+            dest = CTarget(path, "libsimple")
             abi_info = import_abi_info("bindinginfo_libsimple.json")
-            wrapper(dest, abi_info)
+            write_wrapper(dest, abi_info)
 
             headerfile = joinpath(dest.dir, dest.headerbase * ".h")
             @test isfile(headerfile)


### PR DESCRIPTION
- `wrapper` is renamed `write_wrapper`, the verb form being more explicit about the fact that it takes an action that yields a product.
- `CProject` is renamed `CTarget`, to more clearly indicate that it specifies a target for which to generate code.
- introduce `AbstractTarget` as the supertype for all future target types.