### PR TITLE
`import_abi_info` splits to `parse_*` and `read_*`

### DIFF
--- a/src/JuliaLibWrapping.jl
+++ b/src/JuliaLibWrapping.jl
@@ -4,7 +4,7 @@ using OrderedCollections: OrderedDict
 using Graphs: SimpleDiGraph, add_edge!, strongly_connected_components, topological_sort
 using JSON: JSON
 
-export import_abi_info, write_wrapper
+export parse_abi_info, read_abi_info, write_wrapper
 export AbstractTarget, CTarget, ABIInfo
 
 include("abi_import.jl")

--- a/src/abi_import.jl
+++ b/src/abi_import.jl
@@ -214,23 +214,24 @@ end
 
 
 """
-    abi_info = import_abi_info(filename::String)
+    abi_info = parse_abi_info(parsed::AbstractDict)
 
-Extract the signatures of the entrypoints and types from an exported ABI info (JSON) file.
+Build an [`ABIInfo`](@ref) from a parsed `juliac` ABI-info JSON document. `parsed`
+is the dictionary returned by `JSON.parsefile` (or `JSON.parse`) on such a file.
+
+See [`read_abi_info`](@ref) for the file-based convenience.
 """
-function import_abi_info(filename::String)
-    abi_info = JSON.parsefile(filename)
-
+function parse_abi_info(parsed::AbstractDict)
     # Extract all the type descriptors
     typedescs = OrderedDict{Int, TypeDesc}()
-    for type in abi_info["types"]
+    for type in parsed["types"]
         id = Int(type["id"]::Int64)
         typedescs[id] = from_json(TypeDesc, type)
     end
 
     # Then collect the methods
     entrypoints = MethodDesc[]
-    for method in abi_info["functions"]
+    for method in parsed["functions"]
         push!(entrypoints, from_json(MethodDesc, method))
     end
 
@@ -239,4 +240,13 @@ function import_abi_info(filename::String)
     return ABIInfo(typedescs, forward_declared, entrypoints)
 end
 
-import_abi_info(filename::AbstractString) = import_abi_info(String(filename)::String)
+"""
+    abi_info = read_abi_info(filename::AbstractString)
+    abi_info = read_abi_info(io::IO)
+
+Read and parse a `juliac` ABI-info JSON file, returning an [`ABIInfo`](@ref).
+The first form is equivalent to `parse_abi_info(JSON.parsefile(filename))`;
+the second reads the document from a stream.
+"""
+read_abi_info(filename::AbstractString) = parse_abi_info(JSON.parsefile(filename))
+read_abi_info(io::IO) = parse_abi_info(JSON.parse(read(io, String)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using JuliaLibWrapping
 using OrderedCollections
+using JSON: parsefile
 using Test
 using Aqua
 using ExplicitImports
@@ -16,8 +17,8 @@ function onlymatch(f, collection)
 end
 
 @testset "JuliaLibWrapping.jl" begin
-    @testset "import_abi_info" begin
-        abi_info = import_abi_info("bindinginfo_libsimple.json")
+    @testset "parse_abi_info" begin
+        abi_info = parse_abi_info(parsefile("bindinginfo_libsimple.json"))
         (; entrypoints, typeinfo) = abi_info
 
         methdesc = onlymatch(md -> md.symbol == "copyto_and_sum", entrypoints)
@@ -74,6 +75,17 @@ end
         @test tdesc.size == 8
         name2idx = Dict(desc.name => i for (i, desc) in enumerate(values(typeinfo)))
         @test name2idx["CVectorPair{Float32}"] > name2idx["CVector{Float32}"]
+    end
+
+    @testset "read_abi_info" begin
+        from_file = read_abi_info("bindinginfo_libsimple.json")
+        from_dict = parse_abi_info(parsefile("bindinginfo_libsimple.json"))
+        from_io = open(read_abi_info, "bindinginfo_libsimple.json")
+        for other in (from_dict, from_io)
+            @test collect(keys(from_file.typeinfo)) == collect(keys(other.typeinfo))
+            @test from_file.forward_declared == other.forward_declared
+            @test length(from_file.entrypoints) == length(other.entrypoints)
+        end
     end
 
     @testset "sort_declarations!" begin
@@ -164,7 +176,7 @@ end
         mktempdir() do path
             mkpath(path)
             dest = CTarget(path, "libsimple")
-            abi_info = import_abi_info("bindinginfo_libsimple.json")
+            abi_info = read_abi_info("bindinginfo_libsimple.json")
             write_wrapper(dest, abi_info)
 
             headerfile = joinpath(dest.dir, dest.headerbase * ".h")
@@ -190,11 +202,11 @@ end
     end
 
     @testset "ExplicitImports" begin
-        # JSON.parsefile is the canonical JSON.jl entry point but JSON.jl
-        # pre-dates the `public` keyword and never marked it public. Disable
-        # the bundled all-qualified-accesses-are-public check and re-run it
-        # with :parsefile ignored.
+        # JSON.parsefile and JSON.parse are the canonical JSON.jl entry points
+        # but JSON.jl pre-dates the `public` keyword and never marked them
+        # public. Disable the bundled all-qualified-accesses-are-public check
+        # and re-run it with those names ignored.
         test_explicit_imports(JuliaLibWrapping; all_qualified_accesses_are_public=false)
-        test_all_qualified_accesses_are_public(JuliaLibWrapping; ignore=(:parsefile,))
+        test_all_qualified_accesses_are_public(JuliaLibWrapping; ignore=(:parsefile, :parse))
     end
 end


### PR DESCRIPTION
Mirror Base's `read(filename, T)` / `parse(T, str)` pairing. `parse_abi_info` takes an already-parsed JSON dict and does all the ABI-info construction; `read_abi_info` has both filename and IO forms that delegate via `JSON.parsefile` and `JSON.parse` respectively. The pure-dict form makes the parser testable without touching the filesystem.