### PR TITLE
Add JLWStatus error-propagation convention (#15)

### DIFF
--- a/JLWInterop/Project.toml
+++ b/JLWInterop/Project.toml
@@ -1,0 +1,13 @@
+name = "JLWInterop"
+uuid = "65e54657-ed21-41a3-96db-71ab7fa6d94b"
+authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
+version = "0.1.0"
+
+[compat]
+julia = "1.10"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/JLWInterop/src/JLWInterop.jl
+++ b/JLWInterop/src/JLWInterop.jl
@@ -1,0 +1,61 @@
+"""
+    JLWInterop
+
+Canonical types for the JuliaLibWrapping cross-ABI error convention (issue #15).
+
+A library author opts in by including a `JLWStatus` field in any
+`@ccallable`-returned struct; the JuliaLibWrapping Python emitter then
+recognizes the field by struct name and emits code that raises a native
+Python exception when `status.code != 0`.
+
+This package deliberately has no dependencies so it stays
+`juliac --trim`-friendly: it is intended to be a build-time *and* runtime
+dependency of compiled libraries.
+"""
+module JLWInterop
+
+export JLWStatus, jlw_ok, jlw_error
+
+const JLW_MESSAGE_BYTES = 256
+
+"""
+    JLWStatus
+
+ABI-stable status struct. `code == 0` means success; any non-zero value is an
+error code chosen by the library. `message` is a UTF-8, null-terminated
+buffer of fixed length ([`JLW_MESSAGE_BYTES`](@ref) bytes). The fixed buffer
+avoids the ownership/lifetime question that `Cstring`/`Ptr{UInt8}` would raise
+under `--trim`; payload size is bounded but no allocation is required to
+construct one.
+"""
+struct JLWStatus
+    code::Int32
+    message::NTuple{JLW_MESSAGE_BYTES, UInt8}
+end
+
+"""
+    jlw_ok() -> JLWStatus
+
+Return a success status: code 0 with an empty message buffer.
+"""
+jlw_ok() = JLWStatus(Int32(0), ntuple(_ -> 0x00, JLW_MESSAGE_BYTES))
+
+"""
+    jlw_error(code::Integer, msg::AbstractString) -> JLWStatus
+
+Return an error status with the given non-zero `code` and `msg`. `msg` is
+copied into the fixed-size buffer, truncated to `JLW_MESSAGE_BYTES - 1` bytes
+if necessary, and always null-terminated. `code` is converted to `Int32`.
+
+Constructing this status performs no heap allocation.
+"""
+function jlw_error(code::Integer, msg::AbstractString)
+    bytes = codeunits(msg)
+    n = min(length(bytes), JLW_MESSAGE_BYTES - 1)
+    buf = ntuple(JLW_MESSAGE_BYTES) do i
+        i <= n ? bytes[i] : 0x00
+    end
+    return JLWStatus(Int32(code), buf)
+end
+
+end # module

--- a/JLWInterop/test/runtests.jl
+++ b/JLWInterop/test/runtests.jl
@@ -1,0 +1,46 @@
+using JLWInterop
+using Test
+
+@testset "JLWInterop" begin
+    @testset "jlw_ok" begin
+        s = jlw_ok()
+        @test s.code == 0
+        @test all(==(0x00), s.message)
+    end
+
+    @testset "jlw_error: basic" begin
+        s = jlw_error(7, "oops")
+        @test s.code == Int32(7)
+        @test s.message[1:4] == (UInt8('o'), UInt8('o'), UInt8('p'), UInt8('s'))
+        @test s.message[5] == 0x00  # null terminator immediately after
+    end
+
+    @testset "jlw_error: truncation + null-termination" begin
+        # 300-byte message should truncate to 255 bytes + null.
+        long = String(repeat('x', 300))
+        s = jlw_error(1, long)
+        @test s.code == Int32(1)
+        @test all(==(UInt8('x')), s.message[1:255])
+        @test s.message[256] == 0x00
+    end
+
+    @testset "jlw_error: exact-fit message still null-terminated" begin
+        # 255 bytes exactly fills the message slots; byte 256 must remain 0.
+        msg = String(repeat('a', 255))
+        s = jlw_error(2, msg)
+        @test all(==(UInt8('a')), s.message[1:255])
+        @test s.message[256] == 0x00
+    end
+
+    @testset "jlw_error: accepts Int32 and wider integers" begin
+        @test jlw_error(Int32(3), "x").code === Int32(3)
+        @test jlw_error(Int64(4), "x").code === Int32(4)
+    end
+
+    @testset "JLWStatus is bits / C-ABI friendly" begin
+        @test isbitstype(JLWStatus)
+        # 4 bytes for code + 256 for message; alignment may pad to 260 or 264
+        # depending on platform, but the type itself must be bits.
+        @test sizeof(JLWStatus) >= 4 + 256
+    end
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,7 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "Error handling" => "error_handling.md",
     ],
 )
 

--- a/docs/src/error_handling.md
+++ b/docs/src/error_handling.md
@@ -1,0 +1,86 @@
+# Error handling across the ABI
+
+A Julia `throw` inside a `--trim`-compiled `@ccallable` does not become a
+Python exception — at best it aborts the host process. JuliaLibWrapping
+defines a small convention for surfacing errors across the C ABI so that
+generated wrappers can translate them into native exceptions.
+
+## The `JLWStatus` convention
+
+The canonical status struct is defined in the [JLWInterop](https://github.com/JuliaInterop/JuliaLibWrapping.jl/tree/main/JLWInterop)
+subdir package and has the following shape:
+
+```julia
+struct JLWStatus
+    code::Int32                       # 0 == success; non-zero == error
+    message::NTuple{256, UInt8}       # UTF-8, null-terminated
+end
+```
+
+A library opts in by *either*
+
+1. returning a `JLWStatus` directly, or
+2. returning a struct that contains a `JLWStatus` field (any field name).
+
+Either form is recognized by the Python backend.
+
+The fixed 256-byte message buffer is deliberate: a `Cstring` or `Ptr{UInt8}`
+would raise an ownership question (who frees it, when?) that has no good
+answer under `juliac --trim`. An inline buffer keeps `JLWStatus` an `isbits`
+type with no heap allocation, at the cost of a bounded message length.
+
+## Authoring a library
+
+Add `JLWInterop` to your library's project, then construct status values
+with the provided helpers:
+
+```julia
+using JLWInterop
+
+struct ResultStruct
+    status::JLWStatus
+    value::Float64
+end
+
+Base.@ccallable function compute(x::Float64)::ResultStruct
+    x < 0 && return ResultStruct(jlw_error(1, "negative input"), 0.0)
+    return ResultStruct(jlw_ok(), x * 2)
+end
+```
+
+`jlw_ok()` and `jlw_error(code, msg)` perform no heap allocation, so they
+are safe in `--trim` builds.
+
+## What the Python wrapper does
+
+For each entrypoint whose return type carries a `JLWStatus` (directly or via
+an embedded field), the generated wrapper checks `status.code` and raises a
+`JLWError` (a `RuntimeError` subclass, carrying `.code` and `.message`) when
+it is non-zero:
+
+```python
+from mylib import compute, JLWError
+
+try:
+    result = compute(-1.0)
+except JLWError as e:
+    print(e.code, e.message)   # 1, "negative input"
+```
+
+On success the full return struct is handed back unchanged, including the
+status field (so callers can still inspect it explicitly if they prefer).
+
+## C backend
+
+The C header generator does not currently auto-emit a status-check macro;
+C callers should check `result.status.code` themselves and read the message
+with e.g. `printf("%.256s\n", result.status.message)`. A `JLW_CHECK`-style
+helper macro is a possible follow-up.
+
+## Recognition is structural
+
+The Python emitter matches on struct name (`"JLWStatus"`) plus field shape
+(`code::Int32` followed by a 256-byte tuple `message`). Authors who copy and
+paste a compatible definition — rather than depending on JLWInterop — still
+get the same wrapper behavior. The canonical package merely keeps the
+definition from drifting across libraries.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,6 +6,10 @@ CurrentModule = JuliaLibWrapping
 
 Documentation for [JuliaLibWrapping](https://github.com/JuliaInterop/JuliaLibWrapping.jl).
 
+See [Error handling](@ref "Error handling across the ABI") for the
+`JLWStatus` convention that lets wrapped libraries surface errors as native
+exceptions in the target language.
+
 ```@index
 ```
 

--- a/src/python.jl
+++ b/src/python.jl
@@ -52,13 +52,35 @@ const pytypes = Dict{String, String}(
 )
 
 """
+    tuple_struct_info(desc::StructDesc) -> Union{Nothing, Tuple{Int, Int}}
+
+If `desc` is the ABI encoding of a Julia tuple type (e.g. `NTuple{N, T}` —
+which juliac emits as a struct whose fields are named `"1"`, `"2"`, …, `"N"`
+and all share a common type), return `(element_type_id, count)`. Otherwise
+return `nothing`. Such structs are emitted inline as `ctypes` arrays rather
+than as `Structure` subclasses (Python forbids field identifiers that start
+with a digit, and arrays are also more idiomatic for fixed-size byte buffers).
+"""
+function tuple_struct_info(desc::StructDesc)
+    n = length(desc.fields)
+    n == 0 && return nothing
+    eltype_id = desc.fields[1].type
+    for (i, field) in enumerate(desc.fields)
+        field.name == string(i) || return nothing
+        field.type == eltype_id || return nothing
+    end
+    return (eltype_id, n)
+end
+
+"""
     mangle_python!(typedict, type_id, typeinfo) -> String
 
 Return a Python expression naming the ctypes type for `type_id`. Struct names
 go through `sanitize_for_c` (whose output is also a valid Python identifier)
 with a `_<id>` collision suffix matching `mangle_c!`. Pointer types render
 inline as `ctypes.POINTER(...)`; `Ptr{Cvoid}` collapses to `ctypes.c_void_p`.
-Results are memoised in `typedict`.
+Tuple-shaped structs (see [`tuple_struct_info`](@ref)) render inline as
+`(<eltype> * N)`. Results are memoized in `typedict`.
 """
 function mangle_python!(typedict::Dict{Int, String}, type_id::Int,
                         typeinfo::OrderedDict{Int, TypeDesc})
@@ -81,15 +103,22 @@ function mangle_python!(typedict::Dict{Int, String}, type_id::Int,
             mangled = "ctypes.POINTER(" * inner * ")"
         end
     elseif type isa StructDesc
-        mangled = sanitize_for_c(type.name)
-        if mangled in values(typedict)
-            suffix = type_id
-            extended = mangled * "_" * string(suffix)
-            while extended in values(typedict)
-                suffix += 1
+        tinfo = tuple_struct_info(type)
+        if tinfo !== nothing
+            eltype_id, count = tinfo
+            eltype_expr = mangle_python!(typedict, eltype_id, typeinfo)
+            mangled = "(" * eltype_expr * " * " * string(count) * ")"
+        else
+            mangled = sanitize_for_c(type.name)
+            if mangled in values(typedict)
+                suffix = type_id
                 extended = mangled * "_" * string(suffix)
+                while extended in values(typedict)
+                    suffix += 1
+                    extended = mangled * "_" * string(suffix)
+                end
+                mangled = extended
             end
-            mangled = extended
         end
     else
         @assert false "unknown descriptor type"
@@ -119,7 +148,7 @@ that scope (callers should pass one `Set{String}` per scope — e.g. one per
 function signature, one per struct's field list). If the candidate already
 appears in `seen`, an integer suffix (`2`, `3`, …) is appended until the name
 is fresh, skipping any value that itself already collides — so the result is
-safe even when sanitised input happens to look like another argument plus a
+safe even when sanitized input happens to look like another argument plus a
 numeric tail. The chosen name is inserted into `seen` before returning.
 """
 function sanitize_python_argname(name::AbstractString, seen=nothing)
@@ -152,22 +181,29 @@ function write_wrapper(dest::PythonTarget, abi_info::ABIInfo)
     # Pre-mangle every struct so that the order in which `mangle_python!` is
     # first called (which influences collision-suffix allocation) is the
     # declaration order, not the order of first textual reference. This
-    # mirrors the C emitter's behaviour.
+    # mirrors the C emitter's behavior. Tuple-shaped structs are not
+    # pre-mangled because they render inline (as ctypes arrays) and never
+    # contribute a name to the collision pool.
     for (id, type) in pairs(typeinfo)
-        if type isa StructDesc
+        if type isa StructDesc && tuple_struct_info(type) === nothing
             mangle_python!(typedict, id, typeinfo)
         end
     end
 
+    needs_jlwerror = any(jlwstatus_access_path(m, typeinfo) !== nothing
+                        for m in entrypoints)
+
     bindings_path = joinpath(pkgdir, "_bindings.py")
     open(bindings_path, "w") do f
-        _write_bindings(f, dest, abi_info, typedict)
+        _write_bindings(f, dest, abi_info, typedict, needs_jlwerror)
     end
 
-    # Collect the public names for __init__.py re-export.
+    # Collect the public names for __init__.py re-export. Tuple-shaped
+    # structs do not emit a class so they are skipped here.
     exported_names = String[]
+    needs_jlwerror && push!(exported_names, "JLWError")
     for (id, type) in pairs(typeinfo)
-        if type isa StructDesc
+        if type isa StructDesc && tuple_struct_info(type) === nothing
             push!(exported_names, typedict[id])
         end
     end
@@ -207,8 +243,69 @@ function write_wrapper(dest::PythonTarget, abi_info::ABIInfo)
     return nothing
 end
 
+"""
+    is_jlwstatus_struct(desc::StructDesc, typeinfo) -> Bool
+
+Recognize the JLWInterop error-status convention (issue #15) by structural
+shape: a struct named `JLWStatus` with two fields — an integer `code` field
+and a `message` field that is a tuple-of-bytes struct. Matching by name +
+shape (rather than by package identity) means authors who copy-paste a
+compatible definition still get the behavior.
+"""
+function is_jlwstatus_struct(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
+    desc.name == "JLWStatus" || return false
+    length(desc.fields) == 2 || return false
+    code_field, msg_field = desc.fields
+    code_field.name == "code" || return false
+    msg_field.name == "message" || return false
+    code_type = typeinfo[code_field.type]
+    code_type isa PrimitiveTypeDesc || return false
+    code_type.name in ("Int32", "Int64") || return false
+    msg_type = typeinfo[msg_field.type]
+    msg_type isa StructDesc || return false
+    tinfo = tuple_struct_info(msg_type)
+    tinfo === nothing && return false
+    eltype = typeinfo[tinfo[1]]
+    eltype isa PrimitiveTypeDesc && eltype.name == "UInt8" || return false
+    return true
+end
+
+"""
+    jlwstatus_access_path(method, typeinfo) -> Union{Nothing, String}
+
+If `method`'s return type carries a JLWStatus (either the return type *is* a
+JLWStatus or it is a struct with a JLWStatus field), return the Python
+attribute path from `_result` to that status (e.g. `""` for direct return,
+or `".status"` for an embedded field). Otherwise return `nothing`.
+Recognition is shallow on purpose — only the immediate return struct's
+top-level fields are inspected. Implements part of issue #15.
+"""
+function jlwstatus_access_path(method::MethodDesc, typeinfo::OrderedDict{Int, TypeDesc})
+    rt = typeinfo[method.return_type]
+    rt isa StructDesc || return nothing
+    if is_jlwstatus_struct(rt, typeinfo)
+        return ""
+    end
+    for field in rt.fields
+        ftype = typeinfo[field.type]
+        if ftype isa StructDesc && is_jlwstatus_struct(ftype, typeinfo)
+            return "." * sanitize_python_argname(field.name)
+        end
+    end
+    return nothing
+end
+
+const JLWERROR_DEFINITION = """
+class JLWError(RuntimeError):
+    \"\"\"Raised when a wrapped function returns a non-zero JLWStatus.code.\"\"\"
+    def __init__(self, code, message):
+        super().__init__(f"[{code}] {message}")
+        self.code = code
+        self.message = message
+"""
+
 function _write_bindings(f::IO, dest::PythonTarget, abi_info::ABIInfo,
-                         typedict::Dict{Int, String})
+                         typedict::Dict{Int, String}, needs_jlwerror::Bool=false)
     (; entrypoints, typeinfo, forward_declared) = abi_info
     env_var = uppercase(dest.package_name) * "_LIBRARY"
 
@@ -246,22 +343,33 @@ function _write_bindings(f::IO, dest::PythonTarget, abi_info::ABIInfo,
     println(f, "_lib = ctypes.CDLL(_resolve_library_path())")
     println(f)
 
+    if needs_jlwerror
+        # Implements issue #15: error-propagation convention via JLWStatus.
+        print(f, JLWERROR_DEFINITION)
+        println(f)
+    end
+
     # Forward declarations: emit empty Structure subclasses for any recursive
-    # type that the dependency sort could not place.
+    # type that the dependency sort could not place. Tuple-shaped structs
+    # render inline as ctypes arrays so they never need forward declaration.
     if !isempty(forward_declared)
         println(f, "# Forward declarations for recursive types")
         for id in forward_declared
             type = typeinfo[id]
             @assert type isa StructDesc "unexpected forward-declared non-struct"
+            @assert tuple_struct_info(type) === nothing "tuple-shaped struct should not be forward-declared"
             println(f, "class ", typedict[id], "(ctypes.Structure):")
             println(f, "    pass")
             println(f)
         end
     end
 
-    # Struct definitions in dependency order.
+    # Struct definitions in dependency order. Tuple-shaped structs are
+    # emitted inline (as `(<eltype> * N)` ctypes arrays) by `mangle_python!`,
+    # so they get no class of their own.
     for (id, type) in pairs(typeinfo)
         type isa StructDesc || continue
+        tuple_struct_info(type) === nothing || continue
         name = typedict[id]
         field_names_seen = Set{String}()
         if id in forward_declared
@@ -300,8 +408,18 @@ function _write_bindings(f::IO, dest::PythonTarget, abi_info::ABIInfo,
         arg_names_seen = Set{String}()
         argnames = String[sanitize_python_argname(a.name, arg_names_seen) for a in method.args]
 
+        status_path = jlwstatus_access_path(method, typeinfo)
+
         println(f, "def ", method.symbol, "(", join(argnames, ", "), "):")
-        if rt == "None"
+        if status_path !== nothing
+            # Implements issue #15: raise JLWError when status.code != 0.
+            println(f, "    _result = _lib.", method.symbol, "(", join(argnames, ", "), ")")
+            println(f, "    if _result", status_path, ".code != 0:")
+            println(f, "        _msg = bytes(_result", status_path,
+                       ".message).rstrip(b\"\\x00\").decode(\"utf-8\", errors=\"replace\")")
+            println(f, "        raise JLWError(_result", status_path, ".code, _msg)")
+            println(f, "    return _result")
+        elseif rt == "None"
             println(f, "    _lib.", method.symbol, "(", join(argnames, ", "), ")")
         else
             println(f, "    return _lib.", method.symbol, "(", join(argnames, ", "), ")")

--- a/test/bindinginfo_jlwstatus.json
+++ b/test/bindinginfo_jlwstatus.json
@@ -1,0 +1,1924 @@
+{
+  "_comment": "Hand-authored fixture for the JLWStatus convention (issue #15). The 256-field NTuple struct mirrors how juliac/abi_export.jl emits NTuple{256, UInt8}: tuples are not isprimitivetype, so they fall into the 'struct' branch with one field per element, named '1'..'N'. The Python emitter's tuple_struct_info recognizes this shape and renders it as a ctypes array. parse_abi_info ignores unknown top-level keys, so this field is invisible to the parser.",
+  "types": [
+    {
+      "kind": "struct",
+      "name": "NTuple{256, UInt8}",
+      "id": 1,
+      "size": 256,
+      "fields": [
+        {
+          "name": "1",
+          "isptr": false,
+          "offset": 0,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "2",
+          "isptr": false,
+          "offset": 1,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "3",
+          "isptr": false,
+          "offset": 2,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "4",
+          "isptr": false,
+          "offset": 3,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "5",
+          "isptr": false,
+          "offset": 4,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "6",
+          "isptr": false,
+          "offset": 5,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "7",
+          "isptr": false,
+          "offset": 6,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "8",
+          "isptr": false,
+          "offset": 7,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "9",
+          "isptr": false,
+          "offset": 8,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "10",
+          "isptr": false,
+          "offset": 9,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "11",
+          "isptr": false,
+          "offset": 10,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "12",
+          "isptr": false,
+          "offset": 11,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "13",
+          "isptr": false,
+          "offset": 12,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "14",
+          "isptr": false,
+          "offset": 13,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "15",
+          "isptr": false,
+          "offset": 14,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "16",
+          "isptr": false,
+          "offset": 15,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "17",
+          "isptr": false,
+          "offset": 16,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "18",
+          "isptr": false,
+          "offset": 17,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "19",
+          "isptr": false,
+          "offset": 18,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "20",
+          "isptr": false,
+          "offset": 19,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "21",
+          "isptr": false,
+          "offset": 20,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "22",
+          "isptr": false,
+          "offset": 21,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "23",
+          "isptr": false,
+          "offset": 22,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "24",
+          "isptr": false,
+          "offset": 23,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "25",
+          "isptr": false,
+          "offset": 24,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "26",
+          "isptr": false,
+          "offset": 25,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "27",
+          "isptr": false,
+          "offset": 26,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "28",
+          "isptr": false,
+          "offset": 27,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "29",
+          "isptr": false,
+          "offset": 28,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "30",
+          "isptr": false,
+          "offset": 29,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "31",
+          "isptr": false,
+          "offset": 30,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "32",
+          "isptr": false,
+          "offset": 31,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "33",
+          "isptr": false,
+          "offset": 32,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "34",
+          "isptr": false,
+          "offset": 33,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "35",
+          "isptr": false,
+          "offset": 34,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "36",
+          "isptr": false,
+          "offset": 35,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "37",
+          "isptr": false,
+          "offset": 36,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "38",
+          "isptr": false,
+          "offset": 37,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "39",
+          "isptr": false,
+          "offset": 38,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "40",
+          "isptr": false,
+          "offset": 39,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "41",
+          "isptr": false,
+          "offset": 40,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "42",
+          "isptr": false,
+          "offset": 41,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "43",
+          "isptr": false,
+          "offset": 42,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "44",
+          "isptr": false,
+          "offset": 43,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "45",
+          "isptr": false,
+          "offset": 44,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "46",
+          "isptr": false,
+          "offset": 45,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "47",
+          "isptr": false,
+          "offset": 46,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "48",
+          "isptr": false,
+          "offset": 47,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "49",
+          "isptr": false,
+          "offset": 48,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "50",
+          "isptr": false,
+          "offset": 49,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "51",
+          "isptr": false,
+          "offset": 50,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "52",
+          "isptr": false,
+          "offset": 51,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "53",
+          "isptr": false,
+          "offset": 52,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "54",
+          "isptr": false,
+          "offset": 53,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "55",
+          "isptr": false,
+          "offset": 54,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "56",
+          "isptr": false,
+          "offset": 55,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "57",
+          "isptr": false,
+          "offset": 56,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "58",
+          "isptr": false,
+          "offset": 57,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "59",
+          "isptr": false,
+          "offset": 58,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "60",
+          "isptr": false,
+          "offset": 59,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "61",
+          "isptr": false,
+          "offset": 60,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "62",
+          "isptr": false,
+          "offset": 61,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "63",
+          "isptr": false,
+          "offset": 62,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "64",
+          "isptr": false,
+          "offset": 63,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "65",
+          "isptr": false,
+          "offset": 64,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "66",
+          "isptr": false,
+          "offset": 65,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "67",
+          "isptr": false,
+          "offset": 66,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "68",
+          "isptr": false,
+          "offset": 67,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "69",
+          "isptr": false,
+          "offset": 68,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "70",
+          "isptr": false,
+          "offset": 69,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "71",
+          "isptr": false,
+          "offset": 70,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "72",
+          "isptr": false,
+          "offset": 71,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "73",
+          "isptr": false,
+          "offset": 72,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "74",
+          "isptr": false,
+          "offset": 73,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "75",
+          "isptr": false,
+          "offset": 74,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "76",
+          "isptr": false,
+          "offset": 75,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "77",
+          "isptr": false,
+          "offset": 76,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "78",
+          "isptr": false,
+          "offset": 77,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "79",
+          "isptr": false,
+          "offset": 78,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "80",
+          "isptr": false,
+          "offset": 79,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "81",
+          "isptr": false,
+          "offset": 80,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "82",
+          "isptr": false,
+          "offset": 81,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "83",
+          "isptr": false,
+          "offset": 82,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "84",
+          "isptr": false,
+          "offset": 83,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "85",
+          "isptr": false,
+          "offset": 84,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "86",
+          "isptr": false,
+          "offset": 85,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "87",
+          "isptr": false,
+          "offset": 86,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "88",
+          "isptr": false,
+          "offset": 87,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "89",
+          "isptr": false,
+          "offset": 88,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "90",
+          "isptr": false,
+          "offset": 89,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "91",
+          "isptr": false,
+          "offset": 90,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "92",
+          "isptr": false,
+          "offset": 91,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "93",
+          "isptr": false,
+          "offset": 92,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "94",
+          "isptr": false,
+          "offset": 93,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "95",
+          "isptr": false,
+          "offset": 94,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "96",
+          "isptr": false,
+          "offset": 95,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "97",
+          "isptr": false,
+          "offset": 96,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "98",
+          "isptr": false,
+          "offset": 97,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "99",
+          "isptr": false,
+          "offset": 98,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "100",
+          "isptr": false,
+          "offset": 99,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "101",
+          "isptr": false,
+          "offset": 100,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "102",
+          "isptr": false,
+          "offset": 101,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "103",
+          "isptr": false,
+          "offset": 102,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "104",
+          "isptr": false,
+          "offset": 103,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "105",
+          "isptr": false,
+          "offset": 104,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "106",
+          "isptr": false,
+          "offset": 105,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "107",
+          "isptr": false,
+          "offset": 106,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "108",
+          "isptr": false,
+          "offset": 107,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "109",
+          "isptr": false,
+          "offset": 108,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "110",
+          "isptr": false,
+          "offset": 109,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "111",
+          "isptr": false,
+          "offset": 110,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "112",
+          "isptr": false,
+          "offset": 111,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "113",
+          "isptr": false,
+          "offset": 112,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "114",
+          "isptr": false,
+          "offset": 113,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "115",
+          "isptr": false,
+          "offset": 114,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "116",
+          "isptr": false,
+          "offset": 115,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "117",
+          "isptr": false,
+          "offset": 116,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "118",
+          "isptr": false,
+          "offset": 117,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "119",
+          "isptr": false,
+          "offset": 118,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "120",
+          "isptr": false,
+          "offset": 119,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "121",
+          "isptr": false,
+          "offset": 120,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "122",
+          "isptr": false,
+          "offset": 121,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "123",
+          "isptr": false,
+          "offset": 122,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "124",
+          "isptr": false,
+          "offset": 123,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "125",
+          "isptr": false,
+          "offset": 124,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "126",
+          "isptr": false,
+          "offset": 125,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "127",
+          "isptr": false,
+          "offset": 126,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "128",
+          "isptr": false,
+          "offset": 127,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "129",
+          "isptr": false,
+          "offset": 128,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "130",
+          "isptr": false,
+          "offset": 129,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "131",
+          "isptr": false,
+          "offset": 130,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "132",
+          "isptr": false,
+          "offset": 131,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "133",
+          "isptr": false,
+          "offset": 132,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "134",
+          "isptr": false,
+          "offset": 133,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "135",
+          "isptr": false,
+          "offset": 134,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "136",
+          "isptr": false,
+          "offset": 135,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "137",
+          "isptr": false,
+          "offset": 136,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "138",
+          "isptr": false,
+          "offset": 137,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "139",
+          "isptr": false,
+          "offset": 138,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "140",
+          "isptr": false,
+          "offset": 139,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "141",
+          "isptr": false,
+          "offset": 140,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "142",
+          "isptr": false,
+          "offset": 141,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "143",
+          "isptr": false,
+          "offset": 142,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "144",
+          "isptr": false,
+          "offset": 143,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "145",
+          "isptr": false,
+          "offset": 144,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "146",
+          "isptr": false,
+          "offset": 145,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "147",
+          "isptr": false,
+          "offset": 146,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "148",
+          "isptr": false,
+          "offset": 147,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "149",
+          "isptr": false,
+          "offset": 148,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "150",
+          "isptr": false,
+          "offset": 149,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "151",
+          "isptr": false,
+          "offset": 150,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "152",
+          "isptr": false,
+          "offset": 151,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "153",
+          "isptr": false,
+          "offset": 152,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "154",
+          "isptr": false,
+          "offset": 153,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "155",
+          "isptr": false,
+          "offset": 154,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "156",
+          "isptr": false,
+          "offset": 155,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "157",
+          "isptr": false,
+          "offset": 156,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "158",
+          "isptr": false,
+          "offset": 157,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "159",
+          "isptr": false,
+          "offset": 158,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "160",
+          "isptr": false,
+          "offset": 159,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "161",
+          "isptr": false,
+          "offset": 160,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "162",
+          "isptr": false,
+          "offset": 161,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "163",
+          "isptr": false,
+          "offset": 162,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "164",
+          "isptr": false,
+          "offset": 163,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "165",
+          "isptr": false,
+          "offset": 164,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "166",
+          "isptr": false,
+          "offset": 165,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "167",
+          "isptr": false,
+          "offset": 166,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "168",
+          "isptr": false,
+          "offset": 167,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "169",
+          "isptr": false,
+          "offset": 168,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "170",
+          "isptr": false,
+          "offset": 169,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "171",
+          "isptr": false,
+          "offset": 170,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "172",
+          "isptr": false,
+          "offset": 171,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "173",
+          "isptr": false,
+          "offset": 172,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "174",
+          "isptr": false,
+          "offset": 173,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "175",
+          "isptr": false,
+          "offset": 174,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "176",
+          "isptr": false,
+          "offset": 175,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "177",
+          "isptr": false,
+          "offset": 176,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "178",
+          "isptr": false,
+          "offset": 177,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "179",
+          "isptr": false,
+          "offset": 178,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "180",
+          "isptr": false,
+          "offset": 179,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "181",
+          "isptr": false,
+          "offset": 180,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "182",
+          "isptr": false,
+          "offset": 181,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "183",
+          "isptr": false,
+          "offset": 182,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "184",
+          "isptr": false,
+          "offset": 183,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "185",
+          "isptr": false,
+          "offset": 184,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "186",
+          "isptr": false,
+          "offset": 185,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "187",
+          "isptr": false,
+          "offset": 186,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "188",
+          "isptr": false,
+          "offset": 187,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "189",
+          "isptr": false,
+          "offset": 188,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "190",
+          "isptr": false,
+          "offset": 189,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "191",
+          "isptr": false,
+          "offset": 190,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "192",
+          "isptr": false,
+          "offset": 191,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "193",
+          "isptr": false,
+          "offset": 192,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "194",
+          "isptr": false,
+          "offset": 193,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "195",
+          "isptr": false,
+          "offset": 194,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "196",
+          "isptr": false,
+          "offset": 195,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "197",
+          "isptr": false,
+          "offset": 196,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "198",
+          "isptr": false,
+          "offset": 197,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "199",
+          "isptr": false,
+          "offset": 198,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "200",
+          "isptr": false,
+          "offset": 199,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "201",
+          "isptr": false,
+          "offset": 200,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "202",
+          "isptr": false,
+          "offset": 201,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "203",
+          "isptr": false,
+          "offset": 202,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "204",
+          "isptr": false,
+          "offset": 203,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "205",
+          "isptr": false,
+          "offset": 204,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "206",
+          "isptr": false,
+          "offset": 205,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "207",
+          "isptr": false,
+          "offset": 206,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "208",
+          "isptr": false,
+          "offset": 207,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "209",
+          "isptr": false,
+          "offset": 208,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "210",
+          "isptr": false,
+          "offset": 209,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "211",
+          "isptr": false,
+          "offset": 210,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "212",
+          "isptr": false,
+          "offset": 211,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "213",
+          "isptr": false,
+          "offset": 212,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "214",
+          "isptr": false,
+          "offset": 213,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "215",
+          "isptr": false,
+          "offset": 214,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "216",
+          "isptr": false,
+          "offset": 215,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "217",
+          "isptr": false,
+          "offset": 216,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "218",
+          "isptr": false,
+          "offset": 217,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "219",
+          "isptr": false,
+          "offset": 218,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "220",
+          "isptr": false,
+          "offset": 219,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "221",
+          "isptr": false,
+          "offset": 220,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "222",
+          "isptr": false,
+          "offset": 221,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "223",
+          "isptr": false,
+          "offset": 222,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "224",
+          "isptr": false,
+          "offset": 223,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "225",
+          "isptr": false,
+          "offset": 224,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "226",
+          "isptr": false,
+          "offset": 225,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "227",
+          "isptr": false,
+          "offset": 226,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "228",
+          "isptr": false,
+          "offset": 227,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "229",
+          "isptr": false,
+          "offset": 228,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "230",
+          "isptr": false,
+          "offset": 229,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "231",
+          "isptr": false,
+          "offset": 230,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "232",
+          "isptr": false,
+          "offset": 231,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "233",
+          "isptr": false,
+          "offset": 232,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "234",
+          "isptr": false,
+          "offset": 233,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "235",
+          "isptr": false,
+          "offset": 234,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "236",
+          "isptr": false,
+          "offset": 235,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "237",
+          "isptr": false,
+          "offset": 236,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "238",
+          "isptr": false,
+          "offset": 237,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "239",
+          "isptr": false,
+          "offset": 238,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "240",
+          "isptr": false,
+          "offset": 239,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "241",
+          "isptr": false,
+          "offset": 240,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "242",
+          "isptr": false,
+          "offset": 241,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "243",
+          "isptr": false,
+          "offset": 242,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "244",
+          "isptr": false,
+          "offset": 243,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "245",
+          "isptr": false,
+          "offset": 244,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "246",
+          "isptr": false,
+          "offset": 245,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "247",
+          "isptr": false,
+          "offset": 246,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "248",
+          "isptr": false,
+          "offset": 247,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "249",
+          "isptr": false,
+          "offset": 248,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "250",
+          "isptr": false,
+          "offset": 249,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "251",
+          "isptr": false,
+          "offset": 250,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "252",
+          "isptr": false,
+          "offset": 251,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "253",
+          "isptr": false,
+          "offset": 252,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "254",
+          "isptr": false,
+          "offset": 253,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "255",
+          "isptr": false,
+          "offset": 254,
+          "isfieldatomic": false,
+          "type_id": 2
+        },
+        {
+          "name": "256",
+          "isptr": false,
+          "offset": 255,
+          "isfieldatomic": false,
+          "type_id": 2
+        }
+      ],
+      "alignment": 1
+    },
+    {
+      "kind": "primitive",
+      "name": "UInt8",
+      "id": 2,
+      "size": 1,
+      "bits": 8,
+      "signed": false,
+      "alignment": 1
+    },
+    {
+      "kind": "primitive",
+      "name": "Int32",
+      "id": 3,
+      "size": 4,
+      "bits": 32,
+      "signed": true,
+      "alignment": 4
+    },
+    {
+      "kind": "struct",
+      "name": "JLWStatus",
+      "id": 4,
+      "size": 264,
+      "fields": [
+        {
+          "name": "code",
+          "isptr": false,
+          "offset": 0,
+          "isfieldatomic": false,
+          "type_id": 3
+        },
+        {
+          "name": "message",
+          "isptr": false,
+          "offset": 4,
+          "isfieldatomic": false,
+          "type_id": 1
+        }
+      ],
+      "alignment": 4
+    },
+    {
+      "kind": "struct",
+      "name": "ResultStruct",
+      "id": 5,
+      "size": 272,
+      "fields": [
+        {
+          "name": "status",
+          "isptr": false,
+          "offset": 0,
+          "isfieldatomic": false,
+          "type_id": 4
+        },
+        {
+          "name": "value",
+          "isptr": false,
+          "offset": 264,
+          "isfieldatomic": false,
+          "type_id": 6
+        }
+      ],
+      "alignment": 8
+    },
+    {
+      "kind": "primitive",
+      "name": "Float64",
+      "id": 6,
+      "size": 8,
+      "bits": 64,
+      "signed": false,
+      "alignment": 8
+    }
+  ],
+  "functions": [
+    {
+      "returns": {
+        "type_id": 4
+      },
+      "name": "do_thing(x::Int32)",
+      "arguments": [
+        {
+          "name": "x",
+          "type_id": 3
+        }
+      ],
+      "symbol": "do_thing"
+    },
+    {
+      "returns": {
+        "type_id": 5
+      },
+      "name": "compute(x::Float64)",
+      "arguments": [
+        {
+          "name": "x",
+          "type_id": 6
+        }
+      ],
+      "symbol": "compute"
+    },
+    {
+      "returns": {
+        "type_id": 3
+      },
+      "name": "plain_add(a::Int32, b::Int32)",
+      "arguments": [
+        {
+          "name": "a",
+          "type_id": 3
+        },
+        {
+          "name": "b",
+          "type_id": 3
+        }
+      ],
+      "symbol": "plain_add"
+    }
+  ]
+}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -322,6 +322,56 @@ end
         end
     end
 
+    @testset "JLWStatus convention" begin
+        # Implements issue #15: in-band status struct + Python raise-on-error.
+        abi_info = read_abi_info("bindinginfo_jlwstatus.json")
+        mktempdir() do path
+            dest = PythonTarget(path, "demo", "libdemo")
+            write_wrapper(dest, abi_info)
+
+            bindings = read(joinpath(path, "demo", "_bindings.py"), String)
+            init = read(joinpath(path, "demo", "__init__.py"), String)
+
+            # The JLWError exception class is defined once.
+            @test occursin("class JLWError(RuntimeError):", bindings)
+            @test count(==("class JLWError(RuntimeError):"),
+                        split(bindings, '\n')) == 1
+
+            # JLWStatus.message is emitted as a ctypes byte array, not as a
+            # 256-field Structure (this also implicitly tests the new
+            # tuple-struct handling).
+            @test occursin("(\"message\", (ctypes.c_uint8 * 256))", bindings)
+            @test !occursin("NTuple_256_UInt8", bindings)
+
+            # Direct JLWStatus return: check uses `_result.code`.
+            @test occursin(
+                "def do_thing(x):\n    _result = _lib.do_thing(x)\n    if _result.code != 0:",
+                bindings)
+            # Embedded JLWStatus field: check uses `_result.status.code`.
+            @test occursin(
+                "def compute(x):\n    _result = _lib.compute(x)\n    if _result.status.code != 0:",
+                bindings)
+            @test occursin("raise JLWError(_result.status.code, _msg)", bindings)
+            # Non-JLWStatus entrypoint stays a bare mechanical binding.
+            @test occursin(
+                "def plain_add(a, b):\n    return _lib.plain_add(a, b)",
+                bindings)
+
+            # JLWError is re-exported from the package.
+            @test occursin("    JLWError,", init)
+            @test occursin("\"JLWError\"", init)
+
+            python3 = Sys.which("python3")
+            if python3 !== nothing
+                bindings_path = joinpath(path, "demo", "_bindings.py")
+                cmd = `$python3 -c "import ast; ast.parse(open('$bindings_path').read())"`
+                @test success(run(pipeline(cmd; stderr=devnull, stdout=devnull); wait=true))
+            elseif haskey(ENV, "CI")
+                error("python3 not found on PATH; required on CI to validate the emitted wrapper")
+            end
+        end
+    end
+
     @testset "Aqua" begin
         Aqua.test_all(JuliaLibWrapping)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -320,6 +320,31 @@ end
             )
             @test_throws "unsupported primitive type: 'NotARealType'" JuliaLibWrapping.mangle_python!(typedict, 1, typeinfo)
         end
+
+        @testset "struct name collision" begin
+            # Mirrors the mangle_c! collision testset: the Python emitter
+            # carries a near-identical suffix-bumping branch, and the two
+            # implementations must not silently drift.
+            typedict = Dict{Int, String}()
+            typeinfo = OrderedDict{Int, TypeDesc}(
+                1 => StructDesc("Foo!", 0, 0, FieldDesc[]),
+                2 => StructDesc("Foo?", 0, 0, FieldDesc[]),
+                3 => StructDesc("Foo#", 0, 0, FieldDesc[]),
+            )
+            @test JuliaLibWrapping.mangle_python!(typedict, 1, typeinfo) == "Foo"
+            @test JuliaLibWrapping.mangle_python!(typedict, 2, typeinfo) == "Foo_2"
+            @test JuliaLibWrapping.mangle_python!(typedict, 3, typeinfo) == "Foo_3"
+
+            typedict = Dict{Int, String}()
+            typeinfo = OrderedDict{Int, TypeDesc}(
+                1 => StructDesc("Foo", 0, 0, FieldDesc[]),     # takes "Foo"
+                2 => StructDesc("Foo_3", 0, 0, FieldDesc[]),   # takes "Foo_3"
+                3 => StructDesc("Foo!", 0, 0, FieldDesc[]),    # wants "Foo_3", bumps to "Foo_4"
+            )
+            @test JuliaLibWrapping.mangle_python!(typedict, 1, typeinfo) == "Foo"
+            @test JuliaLibWrapping.mangle_python!(typedict, 2, typeinfo) == "Foo_3"
+            @test JuliaLibWrapping.mangle_python!(typedict, 3, typeinfo) == "Foo_4"
+        end
     end
 
     @testset "JLWStatus convention" begin


### PR DESCRIPTION
Introduce the JLWInterop subdir package, which defines a canonical JLWStatus struct (Int32 code + 256-byte UTF-8 message buffer) for surfacing errors across the C ABI without relying on a Julia throw (which juliac --trim strips). The Python emitter recognizes JLWStatus by structural shape, in either of two return-type forms — JLWStatus directly, or a struct with a JLWStatus field — and wraps the call to raise a JLWError on a non-zero code.

Recognition is by name plus field shape rather than by package identity, so authors who copy-paste a compatible definition still get the behavior; the canonical JLWInterop package exists only to keep the definition from drifting across libraries.

Also fix a latent bug in the Python emitter: juliac emits NTuple{N, T} as a struct with fields named "1".."N", which Python rejects as field identifiers. The emitter now detects tuple-shaped structs and renders them inline as `(ctypes.c_uint8 * N)` ctypes arrays, making `bytes(buf)` work naturally on the JLWStatus message field.