### PR TITLE
Add CVector{T} to the JLWInterop cross-ABI vocabulary

### DIFF
--- a/JLWInterop/src/JLWInterop.jl
+++ b/JLWInterop/src/JLWInterop.jl
@@ -1,12 +1,15 @@
 """
     JLWInterop
 
-Canonical types for the JuliaLibWrapping cross-ABI error convention (issue #15).
+Canonical types for JuliaLibWrapping cross-ABI conventions. Provides
+[`JLWStatus`](@ref) for in-band error reporting and [`CVector`](@ref) for
+1-D numeric buffers; both are designed to cross a `@ccallable` boundary.
 
-A library author opts in by including a `JLWStatus` field in any
-`@ccallable`-returned struct; the JuliaLibWrapping Python emitter then
-recognizes the field by struct name and emits code that raises a native
-Python exception when `status.code != 0`.
+A library author opts in by using these types in any `@ccallable`-returned
+or `@ccallable`-accepted struct; the JuliaLibWrapping Python emitter then
+recognizes them by struct name + shape and emits idiomatic code — raising a
+native Python exception on a non-zero `JLWStatus.code`, and exposing
+`from_numpy` / `as_numpy` helpers on each recognized `CVector`.
 
 This package deliberately has no dependencies so it stays
 `juliac --trim`-friendly: it is intended to be a build-time *and* runtime
@@ -15,8 +18,81 @@ dependency of compiled libraries.
 module JLWInterop
 
 export JLWStatus, jlw_ok, jlw_error
+export CVector
 
 const JLW_MESSAGE_BYTES = 256
+
+"""
+    CVector{T}
+
+ABI-stable 1-D buffer descriptor for crossing a `@ccallable` boundary:
+`length` contiguous elements of type `T` starting at `data`. `T` should be
+an `isbits` type, in which case `CVector{T}` is itself `isbits` and
+allocation-free to construct, keeping the type `juliac --trim`-friendly.
+The `length` field is `Int32`, matching the rest of the JLWInterop ABI
+vocabulary.
+
+`CVector{T}` holds a raw pointer; it does **not** own the underlying
+buffer. Whoever allocated the storage (the caller passing the buffer in,
+or the library that returned it) remains responsible for keeping it alive
+for the entire time any `CVector` referring to it is in use, and for
+freeing it afterward. `CVector` performs no allocation, no copy, and no
+finalization.
+
+Use it to expose a 1-D numeric buffer at a `@ccallable` boundary instead of
+a `Vector{T}` (which is not C-ABI compatible). The JuliaLibWrapping Python
+emitter recognizes `CVector{T}` for primitive numeric `T` and generates
+`from_numpy` / `as_numpy` helpers on the corresponding `ctypes.Structure`,
+so the Python caller can pass a `numpy.ndarray` directly.
+
+`CVector{T} <: AbstractVector{T}` and implements `size`, bounds-checked
+`getindex`, and `setindex!` via `unsafe_load` / `unsafe_store!` on `data`.
+That means `CVector` participates in iteration, broadcasting, `sum`, views,
+and any function that accepts an `AbstractVector{T}` — at zero allocation.
+`setindex!` is defined unconditionally, so callers must only invoke it on
+buffers they know to be writable.
+
+# Example
+
+```julia
+using JLWInterop
+
+Base.@ccallable function sum_cvector(v::CVector{Float64})::Float64
+    return sum(v)
+end
+
+Base.@ccallable function copyto_cvector!(dst::CVector{Float64},
+                                         src::CVector{Float64})::Int32
+    n = min(length(dst), length(src))
+    @inbounds for i in 1:n
+        dst[i] = src[i]
+    end
+    return Int32(n)
+end
+```
+
+The caller (in Julia, Python, or C) is responsible for ensuring `v.data`
+points to at least `v.length` valid `T` slots for the duration of the
+call, and that the slots are writable when `setindex!` is used.
+"""
+struct CVector{T} <: AbstractVector{T}
+    length::Int32
+    data::Ptr{T}
+end
+
+Base.size(v::CVector) = (Int(v.length),)
+Base.IndexStyle(::Type{<:CVector}) = IndexLinear()
+
+Base.@propagate_inbounds function Base.getindex(v::CVector, i::Int)
+    @boundscheck checkbounds(v, i)
+    return unsafe_load(v.data, i)
+end
+
+Base.@propagate_inbounds function Base.setindex!(v::CVector{T}, x, i::Int) where {T}
+    @boundscheck checkbounds(v, i)
+    unsafe_store!(v.data, convert(T, x), i)
+    return v
+end
 
 """
     JLWStatus

--- a/JLWInterop/test/runtests.jl
+++ b/JLWInterop/test/runtests.jl
@@ -43,4 +43,55 @@ using Test
         # depending on platform, but the type itself must be bits.
         @test sizeof(JLWStatus) >= 4 + 256
     end
+
+    @testset "CVector AbstractVector interface" begin
+        # `GC.@preserve buf` keeps the backing Vector alive for the duration
+        # of the CVector view — the same pattern any Julia caller would use.
+        buf = Float64[10.0, 20.0, 30.0, 40.0]
+        GC.@preserve buf begin
+            v = CVector{Float64}(Int32(length(buf)), pointer(buf))
+
+            @test v isa AbstractVector{Float64}
+            @test IndexStyle(typeof(v)) === IndexLinear()
+            @test size(v) === (4,)
+            @test length(v) === 4
+            @test eltype(v) === Float64
+
+            # getindex round-trips
+            @test v[1] === 10.0
+            @test v[4] === 40.0
+            @test collect(v) == buf
+
+            # bounds checking actually checks (we now have length info)
+            @test_throws BoundsError v[0]
+            @test_throws BoundsError v[5]
+
+            # AbstractArray machinery just works
+            @test sum(v) === 100.0
+            @test v .+ 1.0 == buf .+ 1.0  # broadcasting allocates a Vector
+
+            # setindex! writes through the pointer back into `buf`
+            v[2] = 99.0
+            @test buf[2] == 99.0
+            @test_throws BoundsError (v[0] = 0.0)
+        end
+    end
+
+    @testset "CVector layout" begin
+        # Layout must match what the JuliaLibWrapping Python emitter expects:
+        # length::Int32 first, data::Ptr{T} second. Helpers on the Python side
+        # construct by keyword, but downstream C code reading the struct
+        # depends on this order being stable.
+        @test fieldnames(CVector) == (:length, :data)
+        @test fieldtype(CVector{Float64}, :length) === Int32
+        @test fieldtype(CVector{Float64}, :data) === Ptr{Float64}
+        @test isbitstype(CVector{Float64})
+        @test fieldoffset(CVector{Float64}, 1) == 0
+        # data follows length, on any supported platform pointer alignment
+        # pads length out to 8 bytes.
+        @test fieldoffset(CVector{Float64}, 2) == 8
+        v = CVector{Float64}(Int32(0), Ptr{Float64}(0))
+        @test v.length === Int32(0)
+        @test v.data === Ptr{Float64}(0)
+    end
 end

--- a/src/python.jl
+++ b/src/python.jl
@@ -128,6 +128,53 @@ function mangle_python!(typedict::Dict{Int, String}, type_id::Int,
     return mangled
 end
 
+const numpy_dtypes = Dict{String, String}(
+    "Int8" => "int8", "Int16" => "int16", "Int32" => "int32", "Int64" => "int64",
+    "UInt8" => "uint8", "UInt16" => "uint16", "UInt32" => "uint32", "UInt64" => "uint64",
+    "Float32" => "float32", "Float64" => "float64",
+)
+
+"""
+    cvector_struct_info(desc::StructDesc, typeinfo) -> Union{Nothing, NamedTuple}
+
+Recognize the JLWInterop `CVector{T}` shape: a struct whose name starts
+with `"CVector"`, with exactly two fields named `length` (a primitive
+integer) and `data` (a pointer to a primitive numeric type recognized by
+[`numpy_dtypes`](@ref)). Returns `(; pointee_name, pointee_ctype, dtype)`
+on a match, otherwise `nothing`. Field order may be either `length, data`
+or `data, length`. Like [`is_jlwstatus_struct`](@ref), recognition is by
+name + shape so authors who copy-paste a compatible definition still get
+the behavior.
+"""
+function cvector_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
+    startswith(desc.name, "CVector") || return nothing
+    length(desc.fields) == 2 || return nothing
+    length_field = nothing
+    data_field = nothing
+    for field in desc.fields
+        if field.name == "length"
+            length_field = field
+        elseif field.name == "data"
+            data_field = field
+        end
+    end
+    (length_field === nothing || data_field === nothing) && return nothing
+    length_type = typeinfo[length_field.type]
+    length_type isa PrimitiveTypeDesc || return nothing
+    length_type.name in keys(numpy_dtypes) || return nothing
+    # Reject Float* and Bool as length types — they're in numpy_dtypes but
+    # only integers make sense for a count.
+    startswith(length_type.name, "Int") || startswith(length_type.name, "UInt") || return nothing
+    data_type = typeinfo[data_field.type]
+    data_type isa PointerDesc || return nothing
+    pointee = typeinfo[data_type.pointee_type]
+    pointee isa PrimitiveTypeDesc || return nothing
+    pointee.name in keys(numpy_dtypes) || return nothing
+    return (; pointee_name = pointee.name,
+              pointee_ctype = pytypes[pointee.name],
+              dtype = numpy_dtypes[pointee.name])
+end
+
 const PYTHON_KEYWORDS = Set{String}([
     "False", "None", "True", "and", "as", "assert", "async", "await", "break",
     "class", "continue", "def", "del", "elif", "else", "except", "finally",
@@ -192,10 +239,13 @@ function write_wrapper(dest::PythonTarget, abi_info::ABIInfo)
 
     needs_jlwerror = any(jlwstatus_access_path(m, typeinfo) !== nothing
                         for m in entrypoints)
+    needs_numpy = any(type isa StructDesc &&
+                      cvector_struct_info(type, typeinfo) !== nothing
+                      for type in values(typeinfo))
 
     bindings_path = joinpath(pkgdir, "_bindings.py")
     open(bindings_path, "w") do f
-        _write_bindings(f, dest, abi_info, typedict, needs_jlwerror)
+        _write_bindings(f, dest, abi_info, typedict, needs_jlwerror, needs_numpy)
     end
 
     # Collect the public names for __init__.py re-export. Tuple-shaped
@@ -237,7 +287,7 @@ function write_wrapper(dest::PythonTarget, abi_info::ABIInfo)
 
     pyproject_path = joinpath(dest.dir, "pyproject.toml")
     open(pyproject_path, "w") do f
-        _write_pyproject(f, dest)
+        _write_pyproject(f, dest, needs_numpy)
     end
 
     return nothing
@@ -246,11 +296,11 @@ end
 """
     is_jlwstatus_struct(desc::StructDesc, typeinfo) -> Bool
 
-Recognize the JLWInterop error-status convention (issue #15) by structural
-shape: a struct named `JLWStatus` with two fields — an integer `code` field
-and a `message` field that is a tuple-of-bytes struct. Matching by name +
-shape (rather than by package identity) means authors who copy-paste a
-compatible definition still get the behavior.
+Recognize the JLWInterop error-status convention by structural shape: a
+struct named `JLWStatus` with two fields — an integer `code` field and a
+`message` field that is a tuple-of-bytes struct. Matching by name + shape
+(rather than by package identity) means authors who copy-paste a compatible
+definition still get the behavior.
 """
 function is_jlwstatus_struct(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
     desc.name == "JLWStatus" || return false
@@ -278,7 +328,7 @@ JLWStatus or it is a struct with a JLWStatus field), return the Python
 attribute path from `_result` to that status (e.g. `""` for direct return,
 or `".status"` for an embedded field). Otherwise return `nothing`.
 Recognition is shallow on purpose — only the immediate return struct's
-top-level fields are inspected. Implements part of issue #15.
+top-level fields are inspected.
 """
 function jlwstatus_access_path(method::MethodDesc, typeinfo::OrderedDict{Int, TypeDesc})
     rt = typeinfo[method.return_type]
@@ -295,6 +345,38 @@ function jlwstatus_access_path(method::MethodDesc, typeinfo::OrderedDict{Int, Ty
     return nothing
 end
 
+function _write_cvector_helpers(f::IO, cvinfo)
+    # `cvinfo` is the return of `cvector_struct_info`. Helpers are emitted as
+    # methods on the surrounding ctypes.Structure subclass; the `length` and
+    # `data` field names are guaranteed by the recognizer.
+    ctype = cvinfo.pointee_ctype
+    dtype = cvinfo.dtype
+    println(f, "")
+    println(f, "    @classmethod")
+    println(f, "    def from_numpy(cls, arr):")
+    println(f, "        \"\"\"Return a CVector view of the 1-D contiguous numpy array `arr`.")
+    println(f, "")
+    println(f, "        Raises ValueError on ndim, contiguity, or dtype mismatch (fail-fast: no")
+    println(f, "        silent reinterpretation). The returned object holds a reference to `arr`,")
+    println(f, "        so the caller must keep it alive for the duration of any C call that uses")
+    println(f, "        the buffer.\"\"\"")
+    println(f, "        if arr.ndim != 1:")
+    println(f, "            raise ValueError(f\"expected 1-D array, got {arr.ndim}-D\")")
+    println(f, "        if not arr.flags.c_contiguous:")
+    println(f, "            raise ValueError(\"array must be C-contiguous\")")
+    println(f, "        expected_dtype = np.dtype(", repr(dtype), ")")
+    println(f, "        if arr.dtype != expected_dtype:")
+    println(f, "            raise ValueError(f\"expected dtype ", dtype, ", got {arr.dtype}\")")
+    println(f, "        obj = cls(length=arr.size,")
+    println(f, "                  data=arr.ctypes.data_as(ctypes.POINTER(", ctype, ")))")
+    println(f, "        obj._buffer = arr")
+    println(f, "        return obj")
+    println(f, "")
+    println(f, "    def as_numpy(self):")
+    println(f, "        \"\"\"Return a 1-D numpy view of the underlying buffer (no copy).\"\"\"")
+    println(f, "        return np.ctypeslib.as_array(self.data, shape=(self.length,))")
+end
+
 const JLWERROR_DEFINITION = """
 class JLWError(RuntimeError):
     \"\"\"Raised when a wrapped function returns a non-zero JLWStatus.code.\"\"\"
@@ -305,7 +387,8 @@ class JLWError(RuntimeError):
 """
 
 function _write_bindings(f::IO, dest::PythonTarget, abi_info::ABIInfo,
-                         typedict::Dict{Int, String}, needs_jlwerror::Bool=false)
+                         typedict::Dict{Int, String}, needs_jlwerror::Bool=false,
+                         needs_numpy::Bool=false)
     (; entrypoints, typeinfo, forward_declared) = abi_info
     env_var = uppercase(dest.package_name) * "_LIBRARY"
 
@@ -314,6 +397,10 @@ function _write_bindings(f::IO, dest::PythonTarget, abi_info::ABIInfo,
     println(f, "import os")
     println(f, "import sys")
     println(f, "import pathlib")
+    if needs_numpy
+        # Implements issue #12: numpy conversion helpers for CVector structs.
+        println(f, "import numpy as np")
+    end
     println(f)
     println(f, "_HERE = pathlib.Path(__file__).resolve().parent")
     println(f, "_LIBRARY_BASENAME = ", repr(dest.library_basename))
@@ -394,6 +481,12 @@ function _write_bindings(f::IO, dest::PythonTarget, abi_info::ABIInfo,
                 end
                 println(f, "    ]")
             end
+            cvinfo = cvector_struct_info(type, typeinfo)
+            if cvinfo !== nothing
+                # Implements issue #12: emit numpy conversion helpers when the
+                # struct matches the CVector{T} shape with a primitive pointee.
+                _write_cvector_helpers(f, cvinfo)
+            end
         end
         println(f)
     end
@@ -428,7 +521,7 @@ function _write_bindings(f::IO, dest::PythonTarget, abi_info::ABIInfo,
     end
 end
 
-function _write_pyproject(f::IO, dest::PythonTarget)
+function _write_pyproject(f::IO, dest::PythonTarget, needs_numpy::Bool=false)
     println(f, "# Auto-generated by JuliaLibWrapping. Edit only if you know what you are doing.")
     println(f, "[build-system]")
     println(f, "requires = [\"setuptools>=64\"]")
@@ -440,6 +533,10 @@ function _write_pyproject(f::IO, dest::PythonTarget)
     println(f, "description = \"Python bindings for ", dest.library_basename,
                ", auto-generated by JuliaLibWrapping\"")
     println(f, "requires-python = \">=3.8\"")
+    if needs_numpy
+        # Implements issue #12: CVector helpers depend on numpy.
+        println(f, "dependencies = [\"numpy>=1.20\"]")
+    end
     println(f)
     println(f, "[tool.setuptools]")
     println(f, "packages = [", repr(dest.package_name), "]")

--- a/test/expected_libsimple_bindings.py
+++ b/test/expected_libsimple_bindings.py
@@ -3,6 +3,7 @@ import ctypes
 import os
 import sys
 import pathlib
+import numpy as np
 
 _HERE = pathlib.Path(__file__).resolve().parent
 _LIBRARY_BASENAME = "libsimple"
@@ -40,6 +41,30 @@ class CVector_Float32(ctypes.Structure):
         ("length", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_float)),
     ]
+
+    @classmethod
+    def from_numpy(cls, arr):
+        """Return a CVector view of the 1-D contiguous numpy array `arr`.
+
+        Raises ValueError on ndim, contiguity, or dtype mismatch (fail-fast: no
+        silent reinterpretation). The returned object holds a reference to `arr`,
+        so the caller must keep it alive for the duration of any C call that uses
+        the buffer."""
+        if arr.ndim != 1:
+            raise ValueError(f"expected 1-D array, got {arr.ndim}-D")
+        if not arr.flags.c_contiguous:
+            raise ValueError("array must be C-contiguous")
+        expected_dtype = np.dtype("float32")
+        if arr.dtype != expected_dtype:
+            raise ValueError(f"expected dtype float32, got {arr.dtype}")
+        obj = cls(length=arr.size,
+                  data=arr.ctypes.data_as(ctypes.POINTER(ctypes.c_float)))
+        obj._buffer = arr
+        return obj
+
+    def as_numpy(self):
+        """Return a 1-D numpy view of the underlying buffer (no copy)."""
+        return np.ctypeslib.as_array(self.data, shape=(self.length,))
 
 class CVectorPair_Float32(ctypes.Structure):
     _fields_ = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -284,6 +284,18 @@ end
             @test occursin("_lib.countsame.argtypes = [ctypes.POINTER(MyTwoVec), ctypes.c_int32]",
                            bindings)
 
+            # Implements issue #12: CVector{primitive} structs gain numpy
+            # conversion helpers; CVector{struct} does not.
+            @test occursin("import numpy as np", bindings)
+            @test occursin("def from_numpy(cls, arr):", bindings)
+            @test occursin("def as_numpy(self):", bindings)
+            @test occursin("expected_dtype = np.dtype(\"float32\")", bindings)
+            @test occursin("ctypes.POINTER(ctypes.c_float)", bindings)
+            # The CVector_CTree_Float64 class has a struct pointee, so the
+            # recognizer must reject it (no helper emission). There is only
+            # one `from_numpy` definition in the file.
+            @test count(s -> occursin("def from_numpy", s), split(bindings, '\n')) == 1
+
             init = read(init_path, String)
             @test occursin("from ._bindings import (", init)
             @test occursin("copyto_and_sum", init)
@@ -292,6 +304,9 @@ end
             pyproject = read(pyproject_path, String)
             @test occursin("[build-system]", pyproject)
             @test occursin("name = \"libsimple\"", pyproject)
+            # The bindings use numpy via the CVector helpers, so numpy must be
+            # declared as a runtime dependency.
+            @test occursin("dependencies = [\"numpy>=1.20\"]", pyproject)
 
             golden = read(joinpath(@__DIR__, "expected_libsimple_bindings.py"), String)
             @test bindings == golden
@@ -345,6 +360,70 @@ end
             @test JuliaLibWrapping.mangle_python!(typedict, 2, typeinfo) == "Foo_3"
             @test JuliaLibWrapping.mangle_python!(typedict, 3, typeinfo) == "Foo_4"
         end
+    end
+
+    @testset "cvector_struct_info" begin
+        # Implements issue #12: structural recognition of the CVector shape.
+        cvinfo = JuliaLibWrapping.cvector_struct_info
+        # The fixture exercises both a matching CVector{Float32} and a
+        # non-matching CVector{CTree{Float64}} (struct pointee).
+        abi = read_abi_info("bindinginfo_libsimple.json")
+        findtype(descs, name) = (k = collect(keys(descs));
+                                 k[findfirst((id)->descs[id].name === name, k)])
+        cv_f32 = abi.typeinfo[findtype(abi.typeinfo, "CVector{Float32}")]
+        cv_tree = abi.typeinfo[findtype(abi.typeinfo, "CVector{CTree{Float64}}")]
+        info = cvinfo(cv_f32, abi.typeinfo)
+        @test info !== nothing
+        @test info.pointee_name == "Float32"
+        @test info.dtype == "float32"
+        @test info.pointee_ctype == "ctypes.c_float"
+        # Struct pointee → no match (no useful numpy mapping).
+        @test cvinfo(cv_tree, abi.typeinfo) === nothing
+
+        # Hand-built rejections: wrong name, wrong field count, wrong field
+        # names, wrong length type (not integer), wrong pointee (struct).
+        primint = PrimitiveTypeDesc("Int32", true, 32, 4, 4)
+        primflt = PrimitiveTypeDesc("Float32", true, 32, 4, 4)
+        primbool = PrimitiveTypeDesc("Bool", false, 8, 1, 1)
+        ptr_to_flt = PointerDesc("Ptr{Float32}", 2)
+        ti = OrderedDict{Int, TypeDesc}(
+            1 => primint, 2 => primflt, 3 => ptr_to_flt,
+            4 => StructDesc("CVector{Float32}", 16, 8, FieldDesc[
+                FieldDesc("length", 1, 0),
+                FieldDesc("data", 3, 8),
+            ]),
+            5 => StructDesc("NotACVector", 16, 8, FieldDesc[
+                FieldDesc("length", 1, 0),
+                FieldDesc("data", 3, 8),
+            ]),
+            6 => StructDesc("CVectorEmpty", 0, 0, FieldDesc[]),
+            7 => StructDesc("CVectorBadNames", 16, 8, FieldDesc[
+                FieldDesc("len", 1, 0),
+                FieldDesc("data", 3, 8),
+            ]),
+            8 => StructDesc("CVectorBadLength", 16, 8, FieldDesc[
+                FieldDesc("length", 2, 0),  # Float length — not integer
+                FieldDesc("data", 3, 8),
+            ]),
+            9 => primbool,
+            10 => StructDesc("CVectorBoolLength", 16, 8, FieldDesc[
+                FieldDesc("length", 9, 0),  # Bool — in numpy_dtypes but not Int/UInt
+                FieldDesc("data", 3, 8),
+            ]),
+        )
+        @test cvinfo(ti[4], ti) !== nothing
+        @test cvinfo(ti[5], ti) === nothing  # wrong name
+        @test cvinfo(ti[6], ti) === nothing  # empty
+        @test cvinfo(ti[7], ti) === nothing  # wrong field names
+        @test cvinfo(ti[8], ti) === nothing  # non-integer length
+        @test cvinfo(ti[10], ti) === nothing # Bool length rejected
+
+        # Field order may be either way.
+        flipped = StructDesc("CVector{Float32}", 16, 8, FieldDesc[
+            FieldDesc("data", 3, 0),
+            FieldDesc("length", 1, 8),
+        ])
+        @test cvinfo(flipped, ti) !== nothing
     end
 
     @testset "JLWStatus convention" begin


### PR DESCRIPTION
Library authors expose 1-D numeric buffers across a @ccallable boundary by handing a CVector{T} (length::Int32, data::Ptr{T}) across instead of a non-ABI Vector{T}. The Python emitter recognizes the struct by name + shape — mirroring the JLWStatus convention — and emits from_numpy / as_numpy helpers on the ctypes.Structure when T is a primitive numeric type, so callers pass a numpy.ndarray directly.

CVector{T} <: AbstractVector{T} with size, bounds-checked getindex via unsafe_load, and setindex! via unsafe_store!, so it participates in iteration, broadcasting, sum, views, etc. without allocation. CVector holds a raw pointer and does not own the buffer; the allocator is responsible for lifetime.

Addresses part of #12