### PR TITLE
Add a build driver and drop x86 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,6 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
-          - x86
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.jl.mem
 /docs/Manifest*.toml
 /docs/build/
+/examples/*/out/
 Manifest.toml
 Manifest-v*.toml
 CLAUDE.md

--- a/Project.toml
+++ b/Project.toml
@@ -6,21 +6,33 @@ authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[weakdeps]
+JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
+
+[extensions]
+JuliaLibWrappingJuliaCExt = "JuliaC"
 
 [compat]
 Aqua = "0.8"
 ExplicitImports = "1.15"
 Graphs = "1"
 JSON = "0.21.4"
+JuliaC = "0.3"
+Libdl = "1"
 OrderedCollections = "1.8.1"
+TOML = "1"
 Test = "1"
 julia = "1.13"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "Test"]
+test = ["Aqua", "ExplicitImports", "JuliaC", "Test"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,6 +10,35 @@ See [Error handling](@ref "Error handling across the ABI") for the
 `JLWStatus` convention that lets wrapped libraries surface errors as native
 exceptions in the target language.
 
+## Driving the pipeline
+
+[`build_library`](@ref) runs the full `juliac` → ABI JSON → wrapper pipeline
+in one call:
+
+```julia
+using JuliaLibWrapping
+using JuliaC
+out = mktempdir()
+result = build_library(
+    joinpath(@__DIR__, "src/mylib.jl"),
+    [CTarget(out, "mylib"), PythonTarget(out, "mylib_py", "mylib")];
+    project = @__DIR__,
+    libname = "mylib",
+    libdir  = out,
+)
+```
+
+`build_library` invokes `juliac` to produce the shared library and ABI JSON,
+then applies [`write_wrapper`](@ref) to each target. The supported route is
+[JuliaC.jl](https://github.com/JuliaLang/JuliaC.jl) (a weak dependency): load
+it with `using JuliaC` before calling `build_library`. ABI developers who want
+to try features ahead of JuliaC.jl can opt into the unstable in-tree
+`share/julia/juliac/juliac.jl` script by passing `backend = :script`.
+
+Relative `[sources]` paths in the entry project's `Project.toml` are rejected
+up front, because `juliac` relocates the project into a temporary directory
+before compiling.
+
 ## Two-tier Python output
 
 `write_wrapper(PythonTarget, …)` emits three files into the generated package

--- a/examples/abi_stress/build.jl
+++ b/examples/abi_stress/build.jl
@@ -1,0 +1,19 @@
+# Build the abi_stress library end-to-end and emit C + Python wrappers.
+# Run from this directory: `julia --project=. build.jl`
+
+using JuliaLibWrapping
+
+const HERE  = @__DIR__
+const OUT   = joinpath(HERE, "out")
+const ENTRY = joinpath(HERE, "src", "abi_stress.jl")
+
+result = build_library(ENTRY,
+    [CTarget(OUT, "abi_stress"),
+     PythonTarget(OUT, "abi_stress_py", "abi_stress")];
+    project = HERE,
+    libname = "abi_stress",
+    libdir  = OUT,
+    verbose = true,
+)
+
+@info "Built abi_stress" library=result.library backend=result.backend

--- a/ext/JuliaLibWrappingJuliaCExt.jl
+++ b/ext/JuliaLibWrappingJuliaCExt.jl
@@ -1,0 +1,28 @@
+module JuliaLibWrappingJuliaCExt
+
+# Implements the :juliac backend of `build_library` using the JuliaC.jl
+# library API. See issue #16.
+
+using JuliaC: ImageRecipe, LinkRecipe, compile_products, link_products
+
+function _build_library_juliac(entry::AbstractString;
+                               project, libname, libdir, abi_path,
+                               trim, compile_ccallable, verbose)
+    out_lib = joinpath(libdir, libname)
+    trim_mode = trim === nothing ? "no" : String(trim)
+    img = ImageRecipe(;
+        output_type = "--output-lib",
+        file = String(entry),
+        project = String(project),
+        trim_mode,
+        add_ccallables = compile_ccallable,
+        export_abi = String(abi_path),
+        verbose,
+    )
+    link = LinkRecipe(; image_recipe = img, outname = out_lib)
+    compile_products(img)
+    link_products(link)
+    return
+end
+
+end # module

--- a/src/JuliaLibWrapping.jl
+++ b/src/JuliaLibWrapping.jl
@@ -4,7 +4,7 @@ using OrderedCollections: OrderedDict
 using Graphs: SimpleDiGraph, add_edge!, strongly_connected_components, topological_sort
 using JSON: JSON
 
-export parse_abi_info, read_abi_info, write_wrapper
+export parse_abi_info, read_abi_info, write_wrapper, build_library
 export AbstractTarget, CTarget, PythonTarget, ABIInfo
 
 include("abi_import.jl")
@@ -13,5 +13,6 @@ abstract type AbstractTarget end
 
 include("c.jl")
 include("python.jl")
+include("build.jl")
 
 end

--- a/src/build.jl
+++ b/src/build.jl
@@ -1,0 +1,178 @@
+# Driver for the juliac → ABI JSON → wrappers pipeline. See issue #16.
+
+using TOML: TOML
+using Libdl: Libdl
+
+const _TRIM_MODES = (:no, :safe, :unsafe, Symbol("unsafe-warn"))
+
+"""
+    build_library(entry, targets;
+                  project=dirname(entry), libname, libdir=pwd(),
+                  abi_path=joinpath(libdir, libname*".abi.json"),
+                  trim=:safe, compile_ccallable=true,
+                  julia=`julia`, backend=:auto, verbose=false)
+
+Run the full `juliac` → ABI JSON → wrapper pipeline in one call.
+
+`entry` is the path to the Julia source file (or package directory) that
+`juliac` will compile; `targets` is a vector of [`AbstractTarget`](@ref)s that
+will each receive a `write_wrapper` call once the ABI JSON is available.
+
+Returns a NamedTuple `(library, abi_path, abi_info, target_outputs, backend)`.
+
+# Backends
+
+The default backend (`:auto`, equivalent to `:juliac`) requires
+[JuliaC.jl](https://github.com/JuliaLang/JuliaC.jl) to be loaded into the
+session (`using JuliaC`); JuliaC.jl ships the stable library API used here
+and is the supported route.
+
+Pass `backend = :script` to opt into the in-tree `share/julia/juliac/juliac.jl`
+script shipped with Julia ≥ 1.13. That script self-declares as unstable; it is
+mainly useful for ABI developers who want to try features before they reach
+JuliaC.jl.
+
+# Example
+
+```julia
+using JuliaLibWrapping
+out = mktempdir()
+result = build_library(
+    joinpath(@__DIR__, "src/mylib.jl"),
+    [CTarget(out, "mylib"), PythonTarget(out, "mylib_py", "mylib")];
+    project = @__DIR__,
+    libname = "mylib",
+    libdir  = out,
+)
+```
+
+# `[sources]` paths must be absolute
+
+`juliac` relocates the project into a temporary directory before compiling.
+Relative `[sources]` paths in the entry project's `Project.toml` cannot be
+resolved from there, so this function rejects them up front. Either use
+absolute paths or `Pkg.develop` the dependency.
+"""
+function build_library(entry::AbstractString,
+                       targets::AbstractVector{<:AbstractTarget};
+                       project::AbstractString = dirname(entry),
+                       libname::AbstractString,
+                       libdir::AbstractString = pwd(),
+                       abi_path::AbstractString = joinpath(libdir, libname * ".abi.json"),
+                       trim::Union{Nothing,Symbol} = :safe,
+                       compile_ccallable::Bool = true,
+                       julia::Cmd = `julia`,
+                       backend::Symbol = :auto,
+                       verbose::Bool = false)
+    isfile(entry) || isdir(entry) ||
+        throw(ArgumentError("entry not found: $entry"))
+    isdir(project) ||
+        throw(ArgumentError("project directory not found: $project"))
+    if trim !== nothing && trim ∉ _TRIM_MODES
+        throw(ArgumentError("trim must be one of $(_TRIM_MODES) or nothing; got :$trim"))
+    end
+    backend ∈ (:auto, :juliac, :script) ||
+        throw(ArgumentError("backend must be :auto, :juliac, or :script; got :$backend"))
+
+    _validate_sources_absolute(project)
+
+    mkpath(libdir)
+    library_path = joinpath(libdir, libname * "." * Libdl.dlext)
+
+    ext = Base.get_extension(@__MODULE__, :JuliaLibWrappingJuliaCExt)
+    chosen = if backend === :script
+        :script
+    else  # :auto or :juliac — both require JuliaC
+        ext === nothing &&
+            throw(ArgumentError("JuliaC.jl is required — run `using JuliaC`, or pass `backend = :script` to use the unstable in-tree `juliac.jl` script shipped with Julia ≥ 1.13."))
+        :juliac
+    end
+
+    if chosen === :juliac
+        ext._build_library_juliac(entry; project, libname, libdir, abi_path,
+                                  trim, compile_ccallable, verbose)
+    else
+        _build_library_script(entry; project, libname, libdir, abi_path,
+                              trim, compile_ccallable, julia, verbose)
+    end
+
+    isfile(abi_path) ||
+        error("juliac completed but no ABI JSON was written to $abi_path")
+    abi_info = read_abi_info(abi_path)
+
+    target_outputs = Vector{NamedTuple}(undef, length(targets))
+    for (i, t) in pairs(targets)
+        write_wrapper(t, abi_info)
+        target_outputs[i] = (target = typeof(t), dir = t.dir)
+    end
+
+    return (; library = library_path, abi_path, abi_info, target_outputs, backend = chosen)
+end
+
+function _validate_sources_absolute(project::AbstractString)
+    pf = joinpath(project, "Project.toml")
+    isfile(pf) || return  # nothing to validate
+    toml = TOML.parsefile(pf)
+    haskey(toml, "sources") || return
+    sources = toml["sources"]
+    sources isa AbstractDict || return
+    for (name, spec) in sources
+        spec isa AbstractDict || continue
+        haskey(spec, "path") || continue
+        p = spec["path"]
+        if !isabspath(p)
+            throw(ArgumentError(
+                """[sources] entry "$name" has relative path "$p" in $pf.
+                juliac copies the project into a temporary directory before compiling,
+                so relative [sources] paths cannot be resolved. Use an absolute path
+                (e.g. `path = $(repr(abspath(joinpath(project, p))))`) or `Pkg.develop`
+                the dependency."""))
+        end
+    end
+    return
+end
+
+function _locate_juliac_script(julia::Cmd)
+    cmd = `$julia --startup-file=no --history-file=no -e 'print(joinpath(Sys.BINDIR, "..", "share", "julia", "juliac", "juliac.jl"))'`
+    path = try
+        strip(read(cmd, String))
+    catch e
+        error("failed to locate juliac.jl via `$julia`: $e")
+    end
+    isfile(path) ||
+        error("juliac.jl not found at $path — Julia ≥ 1.13 is required for the :script backend")
+    return String(path)
+end
+
+function _build_library_script(entry::AbstractString;
+                               project, libname, libdir, abi_path,
+                               trim, compile_ccallable, julia::Cmd, verbose)
+    juliac_jl = _locate_juliac_script(julia)
+    out_lib = joinpath(libdir, libname)
+    args = String[
+        "--startup-file=no", "--history-file=no",
+        juliac_jl,
+        "--project=$project",
+        "--output-lib", out_lib,
+        "--export-abi", String(abi_path),
+    ]
+    compile_ccallable && push!(args, "--compile-ccallable")
+    if trim !== nothing && trim !== :no
+        push!(args, "--experimental")
+        push!(args, "--trim=$(trim)")
+    end
+    verbose && push!(args, "--verbose")
+    push!(args, String(entry))
+    # Clear JULIA_LOAD_PATH / JULIA_PROJECT so the child julia uses its
+    # default load path. juliac.jl does `using LazyArtifacts` at startup,
+    # which needs stdlib reachable; under `Pkg.test` the parent's
+    # restrictive load path would otherwise hide it.
+    cmd = addenv(`$julia $args`,
+                 "JULIA_LOAD_PATH" => nothing,
+                 "JULIA_PROJECT"   => nothing)
+    verbose && @info "Running juliac" cmd
+    proc = run(pipeline(cmd; stdout, stderr); wait = false)
+    wait(proc)
+    success(proc) || error("juliac failed (exit $(proc.exitcode)): $cmd")
+    return
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -798,6 +798,8 @@ end
         end
     end
 
+    include("test_build_library.jl")
+
     @testset "Aqua" begin
         Aqua.test_all(JuliaLibWrapping)
     end

--- a/test/test_build_library.jl
+++ b/test/test_build_library.jl
@@ -1,0 +1,147 @@
+# Tests for `build_library` — see issue #16.
+
+using JuliaLibWrapping
+using JuliaC
+using Test
+
+@testset "build_library" begin
+    @testset "validate [sources] paths" begin
+        mktempdir() do proj
+            open(joinpath(proj, "Project.toml"), "w") do io
+                write(io, """
+                name = "Dummy"
+                uuid = "00000000-0000-0000-0000-000000000000"
+
+                [sources]
+                Foo = {path = "../foo"}
+                """)
+            end
+            entry = joinpath(proj, "src.jl")
+            touch(entry)
+            err = try
+                build_library(entry, AbstractTarget[]; project = proj, libname = "x")
+                nothing
+            catch e
+                e
+            end
+            @test err isa ArgumentError
+            @test occursin("relative path", err.msg)
+            @test occursin("Foo", err.msg)
+        end
+
+        # Absolute path is accepted (validator returns silently). We can't run a
+        # full build without juliac, so just exercise the validator directly.
+        mktempdir() do proj
+            open(joinpath(proj, "Project.toml"), "w") do io
+                write(io, """
+                name = "Dummy"
+                uuid = "00000000-0000-0000-0000-000000000001"
+
+                [sources]
+                Foo = {path = "/tmp/foo"}
+                """)
+            end
+            @test JuliaLibWrapping._validate_sources_absolute(proj) === nothing
+        end
+
+        # No [sources] table at all is fine.
+        mktempdir() do proj
+            open(joinpath(proj, "Project.toml"), "w") do io
+                write(io, "name = \"Dummy\"\nuuid = \"00000000-0000-0000-0000-000000000002\"\n")
+            end
+            @test JuliaLibWrapping._validate_sources_absolute(proj) === nothing
+        end
+    end
+
+    @testset "backend selection" begin
+        # Without JuliaC loaded, the default (:auto) backend must fail-fast
+        # with an actionable message pointing the user at JuliaC.
+        ext = Base.get_extension(JuliaLibWrapping, :JuliaLibWrappingJuliaCExt)
+        entry = joinpath(@__DIR__, "..", "examples", "abi_stress", "src", "abi_stress.jl")
+        proj = joinpath(@__DIR__, "..", "examples", "abi_stress")
+        if ext === nothing
+            for be in (:auto, :juliac)
+                err = try
+                    build_library(entry, AbstractTarget[]; project = proj,
+                                  libname = "abi_stress", backend = be)
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa ArgumentError
+                @test occursin("using JuliaC", err.msg)
+            end
+        end
+
+        # Unknown backend rejected.
+        err = try
+            build_library(entry, AbstractTarget[]; project = proj,
+                          libname = "abi_stress", backend = :bogus)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin(":bogus", err.msg)
+
+        # Unknown trim mode rejected.
+        err = try
+            build_library(entry, AbstractTarget[]; project = proj,
+                          libname = "abi_stress", trim = :wild)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin(":wild", err.msg)
+    end
+
+    @testset "end-to-end" begin
+        # Drive the full pipeline against examples/abi_stress for both
+        # backends. The compile step is expensive (~minutes), so this is
+        # gated on having a usable juliac available. On CI it's a hard
+        # error if the prerequisites are present but the build fails,
+        # mirroring the python3 pattern elsewhere.
+        has_julia = Sys.which("julia") !== nothing
+        has_cc = Sys.which("gcc") !== nothing || Sys.which("clang") !== nothing
+        juliac_ok = has_julia && VERSION >= v"1.13.0-rc1" && has_cc
+        if !juliac_ok
+            @info "Skipping build_library end-to-end test" has_julia has_cc VERSION
+        else
+            entry = joinpath(@__DIR__, "..", "examples", "abi_stress",
+                             "src", "abi_stress.jl")
+            proj  = joinpath(@__DIR__, "..", "examples", "abi_stress")
+            for backend in (:juliac, :script)
+                @testset "backend = $backend" begin
+                    mktempdir() do out
+                        # Use the currently-running interpreter so the
+                        # :script backend works regardless of what
+                        # `julia` resolves to on PATH.
+                        result = build_library(entry,
+                            [CTarget(out, "abi_stress"),
+                             PythonTarget(out, "abi_stress_py", "abi_stress")];
+                            project = proj, libname = "abi_stress",
+                            libdir = out, backend,
+                            julia = Base.julia_cmd())
+                        @test isfile(result.library)
+                        @test isfile(result.abi_path)
+                        @test result.abi_info isa JuliaLibWrapping.ABIInfo
+                        @test result.backend === backend
+
+                        header = read(joinpath(out, "abi_stress.h"), String)
+                        @test occursin("tree_size", header)
+                        @test occursin("countsame", header)
+
+                        lowlevel = joinpath(out, "abi_stress_py", "_lowlevel.py")
+                        @test isfile(lowlevel)
+                        python3 = Sys.which("python3")
+                        if python3 !== nothing
+                            cmd = `$python3 -c "import ast; ast.parse(open('$lowlevel').read())"`
+                            @test success(run(pipeline(cmd; stderr=devnull, stdout=devnull); wait=true))
+                        end
+                    end
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
Adds `build_library`, which combined the `juliac` build step with the binding generation provided by this package. A key role for the driver is to ensure that the right flags are passed to `juliac` to allow binding generation.

This provides support for both JuliaC.jl and the `juliac.jl` script currently shipped with Julia. JuliaC is stable and required-by-default; however, users can override this by passing `backend = :script`. The imagined audience is Julia developers who might want to try new features within the bundled `juliac` before getting them into JuliaC.jl.

JuliaC turns out not to support x86 (or at least doesn't test it), so drop it here too.