### PR TITLE
Bundle-aware Python wrapper output

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,6 +39,67 @@ Relative `[sources]` paths in the entry project's `Project.toml` are rejected
 up front, because `juliac` relocates the project into a temporary directory
 before compiling.
 
+## Bundling for distribution
+
+A `juliac`-compiled `.so` is not self-contained: it links against
+`libjulia`, depends on a sysimage, and pulls in stdlibs and JLL artifacts.
+A Python user who runs `pip install` does not have any of that on their
+machine, so the default flat `lib<name>.so`-next-to-the-package layout
+fails at import time for the actual target audience.
+
+Pass `bundle = true` to [`build_library`](@ref) to also assemble the full
+runtime closure (the `juliac --bundle` layout) and copy it into every
+[`PythonTarget`](@ref)'s package:
+
+```julia
+using JuliaLibWrapping, JuliaC
+out = mktempdir()
+result = build_library(
+    joinpath(@__DIR__, "src/mylib.jl"),
+    [PythonTarget(out, "mylib_py", "mylib"; bundle_subdir = "bundle")];
+    project = @__DIR__,
+    libname = "mylib",
+    libdir  = out,
+    bundle  = true,
+)
+```
+
+The resulting package layout is
+
+    out/mylib_py/
+    ├── __init__.py
+    ├── _facade.py
+    ├── _lowlevel.py
+    ├── pyproject.toml
+    └── bundle/
+        ├── lib/
+        │   ├── libmylib.so       # user lib, RUNPATH=$ORIGIN/[/julia]
+        │   ├── libjulia.so.1.13
+        │   └── julia/…           # libjulia-internal, stdlibs, BLAS, …
+        └── artifacts/…
+
+The generated `_lowlevel.py` loader searches `bundle/lib/` before the
+package root, so the `RUNPATH` baked in at link time resolves `libjulia`
+and friends from inside the wheel — no `LD_LIBRARY_PATH` and no Julia
+install required on the user's machine. A developer who instead drops a
+bare `lib<name>.so` next to the package (without bundling) still works:
+the loader falls back to the flat layout.
+
+`pip install ./out/mylib_py` from a clean virtualenv on a machine
+without a system Julia is the right manual check.
+
+`bundle = true` requires the `:juliac` backend and that each
+[`PythonTarget`](@ref) declare a `bundle_subdir`. The bundle itself is
+multi-hundred-MB (mostly `libLLVM` and `libjulia-codegen`), so it is
+opt-in. Pass `privatize = true` to additionally salt the bundled
+`libjulia` files with a random prefix, avoiding any chance of collision
+with a system `libjulia` loaded by the same process.
+
+Wheel-level packaging (platform tags, `manylinux` audit) is out of scope
+for the current MVP — `pyproject.toml` builds a generic sdist/wheel and
+the developer is responsible for any platform tagging the distribution
+target requires.
+
 ## Two-tier Python output
 
 `write_wrapper(PythonTarget, …)` emits three files into the generated package

--- a/examples/abi_stress/build.jl
+++ b/examples/abi_stress/build.jl
@@ -16,4 +16,19 @@ result = build_library(ENTRY,
     verbose = true,
 )
 
-@info "Built abi_stress" library=result.library backend=result.backend
+# To produce a self-contained Python package that can `pip install` and
+# `import` without a Julia install on the user's machine (see issue #17),
+# pass `bundle = true` and give the PythonTarget a `bundle_subdir`. The
+# bundle is several hundred MiB, so this is opt-in.
+#
+# result = build_library(ENTRY,
+#     [CTarget(OUT, "abi_stress"),
+#      PythonTarget(OUT, "abi_stress_py", "abi_stress"; bundle_subdir = "bundle")];
+#     project = HERE,
+#     libname = "abi_stress",
+#     libdir  = OUT,
+#     bundle  = true,
+#     verbose = true,
+# )
+
+@info "Built abi_stress" library=result.library backend=result.backend bundle=result.bundle_dir

--- a/ext/JuliaLibWrappingJuliaCExt.jl
+++ b/ext/JuliaLibWrappingJuliaCExt.jl
@@ -1,13 +1,23 @@
 module JuliaLibWrappingJuliaCExt
 
 # Implements the :juliac backend of `build_library` using the JuliaC.jl
-# library API. See issue #16.
+# library API. See issues #16 (driver) and #17 (bundling).
 
-using JuliaC: ImageRecipe, LinkRecipe, compile_products, link_products
+using JuliaC: ImageRecipe, LinkRecipe, BundleRecipe,
+              compile_products, link_products, bundle_products
+
+# `LinkRecipe.rpath` accepts the documented public magic string "@bundle"
+# (JuliaC exposes this in the LinkRecipe docstring); the corresponding
+# `RPATH_BUNDLE` constant is internal, so we use the string form to keep
+# the import surface public.
+const _RPATH_BUNDLE = "@bundle"
 
 function _build_library_juliac(entry::AbstractString;
                                project, libname, libdir, abi_path,
-                               trim, compile_ccallable, verbose)
+                               trim, compile_ccallable, verbose,
+                               bundle::Bool = false,
+                               bundle_dir::Union{Nothing,AbstractString} = nothing,
+                               privatize::Bool = false)
     out_lib = joinpath(libdir, libname)
     trim_mode = trim === nothing ? "no" : String(trim)
     img = ImageRecipe(;
@@ -19,9 +29,20 @@ function _build_library_juliac(entry::AbstractString;
         export_abi = String(abi_path),
         verbose,
     )
-    link = LinkRecipe(; image_recipe = img, outname = out_lib)
+    # Bundling requires the bundle-relative rpath at link time; otherwise the
+    # produced .so bakes in absolute paths to the host's Julia install and
+    # cannot be relocated into a wheel.
+    link = LinkRecipe(; image_recipe = img, outname = out_lib,
+                      rpath = bundle ? _RPATH_BUNDLE : "@julia")
     compile_products(img)
     link_products(link)
+    if bundle
+        bundle_dir === nothing && error("internal: bundle_dir must be set when bundle = true")
+        recipe = BundleRecipe(; link_recipe = link,
+                              output_dir = String(bundle_dir),
+                              privatize = privatize)
+        bundle_products(recipe)
+    end
     return
 end
 

--- a/src/build.jl
+++ b/src/build.jl
@@ -10,7 +10,9 @@ const _TRIM_MODES = (:no, :safe, :unsafe, Symbol("unsafe-warn"))
                   project=dirname(entry), libname, libdir=pwd(),
                   abi_path=joinpath(libdir, libname*".abi.json"),
                   trim=:safe, compile_ccallable=true,
-                  julia=`julia`, backend=:auto, verbose=false)
+                  julia=`julia`, backend=:auto, verbose=false,
+                  bundle=false, bundle_dir=joinpath(libdir, libname*"-bundle"),
+                  privatize=false)
 
 Run the full `juliac` → ABI JSON → wrapper pipeline in one call.
 
@@ -18,7 +20,9 @@ Run the full `juliac` → ABI JSON → wrapper pipeline in one call.
 `juliac` will compile; `targets` is a vector of [`AbstractTarget`](@ref)s that
 will each receive a `write_wrapper` call once the ABI JSON is available.
 
-Returns a NamedTuple `(library, abi_path, abi_info, target_outputs, backend)`.
+Returns a NamedTuple `(library, abi_path, abi_info, target_outputs, backend,
+bundle_dir)`. `bundle_dir` is the path to the produced bundle tree when
+`bundle = true`, and `nothing` otherwise.
 
 # Backends
 
@@ -52,6 +56,26 @@ result = build_library(
 Relative `[sources]` paths in the entry project's `Project.toml` cannot be
 resolved from there, so this function rejects them up front. Either use
 absolute paths or `Pkg.develop` the dependency.
+
+# Bundling for distribution (issue #17)
+
+A juliac-produced `.so` depends on `libjulia`, a sysimage, stdlibs, and
+artifacts — none of which a `pip install`-ing Python user has on their
+machine. Pass `bundle = true` to also produce a self-contained directory
+tree (the `juliac --bundle` layout) and copy it into every
+[`PythonTarget`](@ref)'s package. The Python loader generated for those
+targets searches the bundle first, so the baked-in `RUNPATH` resolves
+`libjulia` from inside the wheel at import time.
+
+`bundle = true` requires the `:juliac` backend and that each [`PythonTarget`](@ref)
+declare a `bundle_subdir` (e.g.
+`PythonTarget(out, "mylib_py", "mylib"; bundle_subdir = "bundle")`).
+Targets that are not Python (e.g. [`CTarget`](@ref)) are unaffected — C
+consumers manage their own linkage.
+
+`privatize = true` salts the bundled libjulia files with a random prefix so
+they cannot collide with a system libjulia. Off by default; opt in if the
+wrapper might be loaded into a process that also has a different libjulia.
 """
 function build_library(entry::AbstractString,
                        targets::AbstractVector{<:AbstractTarget};
@@ -63,7 +87,10 @@ function build_library(entry::AbstractString,
                        compile_ccallable::Bool = true,
                        julia::Cmd = `julia`,
                        backend::Symbol = :auto,
-                       verbose::Bool = false)
+                       verbose::Bool = false,
+                       bundle::Bool = false,
+                       bundle_dir::AbstractString = joinpath(libdir, libname * "-bundle"),
+                       privatize::Bool = false)
     isfile(entry) || isdir(entry) ||
         throw(ArgumentError("entry not found: $entry"))
     isdir(project) ||
@@ -73,6 +100,18 @@ function build_library(entry::AbstractString,
     end
     backend ∈ (:auto, :juliac, :script) ||
         throw(ArgumentError("backend must be :auto, :juliac, or :script; got :$backend"))
+    if bundle && backend === :script
+        throw(ArgumentError("bundle = true requires backend = :juliac; the :script backend does not expose the bundle hook used here."))
+    end
+    if bundle
+        for t in targets
+            t isa PythonTarget || continue
+            t.bundle_subdir === nothing && throw(ArgumentError(
+                "PythonTarget for package \"$(t.package_name)\" needs `bundle_subdir = \"bundle\"` " *
+                "(or some other subdir name) when `build_library` is called with `bundle = true`; " *
+                "the bundle tree is copied into that subdirectory of the package."))
+        end
+    end
 
     _validate_sources_absolute(project)
 
@@ -90,7 +129,9 @@ function build_library(entry::AbstractString,
 
     if chosen === :juliac
         ext._build_library_juliac(entry; project, libname, libdir, abi_path,
-                                  trim, compile_ccallable, verbose)
+                                  trim, compile_ccallable, verbose,
+                                  bundle, bundle_dir = (bundle ? bundle_dir : nothing),
+                                  privatize)
     else
         _build_library_script(entry; project, libname, libdir, abi_path,
                               trim, compile_ccallable, julia, verbose)
@@ -100,13 +141,37 @@ function build_library(entry::AbstractString,
         error("juliac completed but no ABI JSON was written to $abi_path")
     abi_info = read_abi_info(abi_path)
 
+    if bundle
+        isdir(bundle_dir) ||
+            error("juliac --bundle completed but no bundle tree at $bundle_dir")
+        for t in targets
+            t isa PythonTarget || continue
+            _copy_bundle_into_python_package(t, bundle_dir)
+        end
+    end
+
     target_outputs = Vector{NamedTuple}(undef, length(targets))
     for (i, t) in pairs(targets)
         write_wrapper(t, abi_info)
         target_outputs[i] = (target = typeof(t), dir = t.dir)
     end
 
-    return (; library = library_path, abi_path, abi_info, target_outputs, backend = chosen)
+    return (; library = library_path, abi_path, abi_info, target_outputs,
+            backend = chosen, bundle_dir = bundle ? bundle_dir : nothing)
+end
+
+# Copy the juliac --bundle tree into a Python package. Run before
+# `write_wrapper` so the package directory always exists with the runtime
+# closure in place; `write_wrapper` then drops the Python sources alongside.
+function _copy_bundle_into_python_package(t::PythonTarget, bundle_dir::AbstractString)
+    pkgdir = joinpath(t.dir, t.package_name)
+    mkpath(pkgdir)
+    dest = joinpath(pkgdir, t.bundle_subdir::String)
+    # Wipe any stale copy so a smaller-than-before bundle does not leave
+    # orphan files behind that the new package-data manifest would pick up.
+    ispath(dest) && rm(dest; recursive = true)
+    cp(bundle_dir, dest)
+    return dest
 end
 
 function _validate_sources_absolute(project::AbstractString)

--- a/src/python.jl
+++ b/src/python.jl
@@ -1,5 +1,5 @@
 """
-    PythonTarget(dir, package_name, library_basename)
+    PythonTarget(dir, package_name, library_basename; bundle_subdir = nothing)
 
 Output configuration for a Python ctypes-based wrapper package. `dir` is the
 directory into which the package will be written; a sub-directory named
@@ -7,16 +7,35 @@ directory into which the package will be written; a sub-directory named
 is the shared library's basename without an OS-specific suffix (e.g. `"libsimple"`,
 which will be loaded from `libsimple.so` / `libsimple.dylib` / `libsimple.dll`
 depending on the host).
+
+When `bundle_subdir` is a string (e.g. `"bundle"`), the emitter assumes the
+shared library and its juliac runtime closure (`libjulia`, sysimage, stdlibs,
+artifacts) will be laid out under that subdirectory of the Python package in
+the standard `--bundle` shape (`<bundle_subdir>/lib/<lib>`,
+`<bundle_subdir>/lib/julia/`, `<bundle_subdir>/artifacts/`). The generated
+loader looks for the library inside the bundle first, the generated
+`pyproject.toml` widens `package-data` to include the bundle tree, and
+[`build_library`](@ref) with `bundle = true` will copy the bundle there.
+The default `nothing` preserves the flat single-`.so`-next-to-the-package
+layout and is the right choice for callers placing the library by hand.
 """
 struct PythonTarget <: AbstractTarget
     dir::String
     package_name::String
     library_basename::String
+    bundle_subdir::Union{Nothing, String}
 end
+
+PythonTarget(dir::AbstractString, package_name::AbstractString,
+             library_basename::AbstractString; bundle_subdir = nothing) =
+    PythonTarget(String(dir), String(package_name), String(library_basename),
+                 bundle_subdir === nothing ? nothing : String(bundle_subdir))
 
 function Base.show(io::IO, t::PythonTarget)
     print(io, "PythonTarget(", repr(t.dir), ", ", repr(t.package_name),
-              ", ", repr(t.library_basename), ")")
+              ", ", repr(t.library_basename))
+    t.bundle_subdir === nothing || print(io, "; bundle_subdir = ", repr(t.bundle_subdir))
+    print(io, ")")
 end
 
 const pytypes = Dict{String, String}(
@@ -600,11 +619,27 @@ function _write_bindings(f::IO, dest::PythonTarget, abi_info::ABIInfo,
     println(f, "    else:")
     println(f, "        suffixes = (\".so\", \".dylib\")")
     println(f, "    tried = []")
-    println(f, "    for suffix in suffixes:")
-    println(f, "        candidate = _HERE / (_LIBRARY_BASENAME + suffix)")
-    println(f, "        tried.append(str(candidate))")
-    println(f, "        if candidate.exists():")
-    println(f, "            return str(candidate)")
+    if dest.bundle_subdir !== nothing
+        # Bundle-aware layout: search the juliac --bundle tree first so the
+        # baked-in RUNPATH (`$ORIGIN/../lib[/julia]` on Linux,
+        # `@loader_path/../lib*` on macOS) resolves libjulia and friends from
+        # inside the bundle. Fall back to the flat layout so the same loader
+        # still works for a developer who drops a bare .so beside the package.
+        println(f, "    search_dirs = (_HERE / ", repr(dest.bundle_subdir),
+                   " / \"lib\", _HERE)")
+        println(f, "    for directory in search_dirs:")
+        println(f, "        for suffix in suffixes:")
+        println(f, "            candidate = directory / (_LIBRARY_BASENAME + suffix)")
+        println(f, "            tried.append(str(candidate))")
+        println(f, "            if candidate.exists():")
+        println(f, "                return str(candidate)")
+    else
+        println(f, "    for suffix in suffixes:")
+        println(f, "        candidate = _HERE / (_LIBRARY_BASENAME + suffix)")
+        println(f, "        tried.append(str(candidate))")
+        println(f, "        if candidate.exists():")
+        println(f, "            return str(candidate)")
+    end
     println(f, "    raise FileNotFoundError(")
     println(f, "        f\"Could not locate shared library {_LIBRARY_BASENAME!r}. \"")
     println(f, "        f\"Tried: {tried}. Set {_LIBRARY_ENV_VAR} to an explicit path.\"")
@@ -997,5 +1032,24 @@ function _write_pyproject(f::IO, dest::PythonTarget, needs_numpy::Bool=false)
     println(f, "packages = [", repr(dest.package_name), "]")
     println(f)
     println(f, "[tool.setuptools.package-data]")
-    println(f, dest.package_name, " = [\"*.so\", \"*.dylib\", \"*.dll\"]")
+    if dest.bundle_subdir === nothing
+        println(f, dest.package_name, " = [\"*.so\", \"*.dylib\", \"*.dll\"]")
+    else
+        # Setuptools' package-data does not recurse, so each level of the
+        # `juliac --bundle` tree (lib/, lib/julia/, artifacts/**) must be
+        # enumerated. Native-library suffixes are listed redundantly with
+        # `*` so a developer who hand-drops a bare lib next to the package
+        # still gets it picked up.
+        sub = dest.bundle_subdir
+        globs = [
+            "\"*.so\"", "\"*.dylib\"", "\"*.dll\"",
+            "\"$sub/lib/*\"",
+            "\"$sub/lib/julia/*\"",
+            "\"$sub/bin/*\"",
+            "\"$sub/artifacts/*\"",
+            "\"$sub/artifacts/*/*\"",
+            "\"$sub/artifacts/*/**/*\"",
+        ]
+        println(f, dest.package_name, " = [", join(globs, ", "), "]")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -348,6 +348,40 @@ end
             t = PythonTarget("/tmp/foo", "libsimple", "libsimple")
             @test sprint(show, t) ==
                   "PythonTarget(\"/tmp/foo\", \"libsimple\", \"libsimple\")"
+            tb = PythonTarget("/tmp/foo", "libsimple", "libsimple";
+                              bundle_subdir = "bundle")
+            @test sprint(show, tb) ==
+                  "PythonTarget(\"/tmp/foo\", \"libsimple\", \"libsimple\"; bundle_subdir = \"bundle\")"
+            @test tb.bundle_subdir == "bundle"
+        end
+
+        @testset "bundle-aware output (issue #17)" begin
+            abi_info = read_abi_info("bindinginfo_libsimple.json")
+            mktempdir() do path
+                dest = PythonTarget(path, "libsimple", "libsimple";
+                                    bundle_subdir = "bundle")
+                write_wrapper(dest, abi_info)
+
+                bindings = read(joinpath(path, "libsimple", "_lowlevel.py"), String)
+                # Bundle path is searched first so the baked-in RUNPATH
+                # resolves libjulia from inside the wheel.
+                @test occursin("search_dirs = (_HERE / \"bundle\" / \"lib\", _HERE)", bindings)
+                @test occursin("for directory in search_dirs:", bindings)
+                @test occursin("candidate = directory / (_LIBRARY_BASENAME + suffix)", bindings)
+                @test occursin("_LIBRARY_ENV_VAR = \"LIBSIMPLE_LIBRARY\"", bindings)
+
+                pyproject = read(joinpath(path, "pyproject.toml"), String)
+                @test occursin("\"bundle/lib/*\"", pyproject)
+                @test occursin("\"bundle/lib/julia/*\"", pyproject)
+                @test occursin("\"bundle/artifacts/*/**/*\"", pyproject)
+
+                python3 = Sys.which("python3")
+                if python3 !== nothing
+                    bp = joinpath(path, "libsimple", "_lowlevel.py")
+                    cmd = `$python3 -c "import ast; ast.parse(open('$bp').read())"`
+                    @test success(run(pipeline(cmd; stderr=devnull, stdout=devnull); wait=true))
+                end
+            end
         end
 
         @testset "unsupported primitive" begin

--- a/test/test_build_library.jl
+++ b/test/test_build_library.jl
@@ -96,6 +96,39 @@ using Test
         @test occursin(":wild", err.msg)
     end
 
+    @testset "bundle validation (issue #17)" begin
+        entry = joinpath(@__DIR__, "..", "examples", "abi_stress", "src", "abi_stress.jl")
+        proj  = joinpath(@__DIR__, "..", "examples", "abi_stress")
+
+        # bundle = true is incompatible with the :script backend.
+        err = try
+            build_library(entry, AbstractTarget[]; project = proj,
+                          libname = "abi_stress", backend = :script,
+                          bundle = true)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("requires backend = :juliac", err.msg)
+
+        # bundle = true with a PythonTarget lacking bundle_subdir must
+        # fail-fast: silently writing into the package would leave the
+        # generated loader looking in the wrong place.
+        err = try
+            build_library(entry,
+                [PythonTarget("/tmp", "pkg", "libfoo")];
+                project = proj, libname = "abi_stress",
+                bundle = true)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("needs `bundle_subdir", err.msg)
+        @test occursin("\"pkg\"", err.msg)
+    end
+
     @testset "end-to-end" begin
         # Drive the full pipeline against examples/abi_stress for both
         # backends. The compile step is expensive (~minutes), so this is
@@ -142,6 +175,54 @@ using Test
                     end
                 end
             end
+        end
+    end
+
+    @testset "end-to-end with bundle (issue #17)" begin
+        # Opt-in: the bundle build copies libjulia + stdlibs + artifacts
+        # and is multi-hundred-MB, so we don't run it in default CI. Set
+        # JLW_TEST_BUNDLE=true to exercise it locally; the test then runs
+        # `python3 -c 'import abi_stress_py'` against the generated
+        # package as the real "does the wheel work?" check.
+        get(ENV, "JLW_TEST_BUNDLE", "false") == "true" || (@info "Skipping bundle e2e test (set JLW_TEST_BUNDLE=true to run)"; return)
+        ext = Base.get_extension(JuliaLibWrapping, :JuliaLibWrappingJuliaCExt)
+        ext === nothing && error("JLW_TEST_BUNDLE set but JuliaC.jl is not loaded")
+        VERSION >= v"1.13.0-rc1" || error("JLW_TEST_BUNDLE set but julia < 1.13")
+        python3 = Sys.which("python3")
+        python3 === nothing && error("JLW_TEST_BUNDLE set but python3 not on PATH")
+        # The generated _lowlevel.py imports numpy (CVector helpers).
+        # Surface that gap up-front rather than failing inside the import
+        # with a confusing-looking error.
+        has_numpy = success(run(pipeline(`$python3 -c "import numpy"`;
+                                        stderr=devnull, stdout=devnull); wait=true))
+        has_numpy || error("JLW_TEST_BUNDLE set but `python3 -c 'import numpy'` failed; install numpy in this python")
+
+        entry = joinpath(@__DIR__, "..", "examples", "abi_stress",
+                         "src", "abi_stress.jl")
+        proj  = joinpath(@__DIR__, "..", "examples", "abi_stress")
+        mktempdir() do out
+            result = build_library(entry,
+                [PythonTarget(out, "abi_stress_py", "abi_stress";
+                              bundle_subdir = "bundle")];
+                project = proj, libname = "abi_stress",
+                libdir = out, bundle = true)
+            @test result.bundle_dir !== nothing
+            @test isdir(result.bundle_dir)
+
+            pkgdir = joinpath(out, "abi_stress_py")
+            bundled_lib = joinpath(pkgdir, "bundle", "lib",
+                                   "abi_stress." * Base.Libc.Libdl.dlext)
+            @test isfile(bundled_lib)
+            # libjulia must be next to the user lib so the baked-in
+            # RUNPATH ($ORIGIN/../lib[/julia]) resolves it.
+            @test any(startswith.(readdir(joinpath(pkgdir, "bundle", "lib")), "libjulia"))
+
+            # The real test: can Python import the package and call a
+            # function? `out` is added to PYTHONPATH so `abi_stress_py`
+            # is importable without `pip install`.
+            cmd = addenv(`$python3 -c "import abi_stress_py; print('ok')"`,
+                         "PYTHONPATH" => out)
+            @test success(run(pipeline(cmd; stderr=stderr, stdout=stdout); wait=true))
         end
     end
 end


### PR DESCRIPTION
A juliac-compiled `.so` depends on `libjulia`, a sysimage, stdlibs, and artifacts. The flat single-`.so`-next-to-package layout the Python emitter produced before this change fails at import time for the actual target audience of `pip install`-ing scientific users.

Pass `bundle = true` to `build_library` to also assemble the `juliac --bundle` runtime closure and copy it into every `PythonTarget`'s package under a `bundle_subdir` (e.g. `bundle/lib/`). The generated `_lowlevel.py` loader searches that subdirectory first, so the link-time `RUNPATH` (`$ORIGIN/../lib[/julia]` on Linux, `@loader_path/../lib*` on macOS) resolves libjulia and friends from inside the wheel — no Julia install required on the user's machine.

- `PythonTarget(...; bundle_subdir = "bundle")` opts the emitter into the bundle-aware loader and widened `pyproject.toml` `package-data` globs. Default `nothing` preserves the flat layout for callers that place the library by hand.
- `build_library(...; bundle = true, privatize = false)` orchestrates the bundle step. Requires the `:juliac` backend (the `:script` route stays bundle-unaware) and rejects `PythonTarget`s lacking a `bundle_subdir` up front.
- JuliaC backend extended to set `LinkRecipe.rpath = "@bundle"` at link time and call `bundle_products(BundleRecipe(...))` afterward.
- Tests: bundle-aware loader/pyproject assertions, two new fail-fast validation paths, and an opt-in (`JLW_TEST_BUNDLE=true`) end-to-end test that actually `import`s the bundled package via python3 — confirms libjulia resolution via the bundled RUNPATH.
- Docs: "Bundling for distribution" section in `docs/src/index.md` with the layout, opt-in instructions, `privatize` note, and explicit deferral of wheel platform tagging to a follow-up.

Sharing a process with another JLW library is a known limitation, tracked in #28.

Fixes #17