### PR TITLE
Prefix `_` to digit-starting Python identifiers (part 1 of #21)

### DIFF
--- a/src/python.jl
+++ b/src/python.jl
@@ -312,8 +312,10 @@ const PYTHON_KEYWORDS = Set{String}([
     sanitize_python_argname(name, seen::Set{String}) -> String
 
 Return a Python-identifier form of `name`: characters illegal in identifiers
-are stripped via [`sanitize_for_c`](@ref), an empty result becomes `"_"`, and
-any reserved Python keyword is suffixed with `_`.
+are stripped via [`sanitize_for_c`](@ref), an empty result becomes `"_"`, a
+leading digit (legal in juliac-emitted tuple field names like `"1"`, `"2"`,
+…, but illegal in a Python identifier) is prefixed with `_`, and any reserved
+Python keyword is suffixed with `_`.
 
 When a `seen` set is supplied, the returned name is also made unique within
 that scope (callers should pass one `Set{String}` per scope — e.g. one per
@@ -326,6 +328,7 @@ numeric tail. The chosen name is inserted into `seen` before returning.
 function sanitize_python_argname(name::AbstractString, seen=nothing)
     sanitized = sanitize_for_c(name)
     isempty(sanitized) && (sanitized = "_")
+    isdigit(first(sanitized)) && (sanitized = "_" * sanitized)
     sanitized in PYTHON_KEYWORDS && (sanitized *= "_")
     if seen !== nothing
         if sanitized in seen

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -416,6 +416,23 @@ end
             @test JuliaLibWrapping.mangle_python!(typedict, 2, typeinfo) == "Foo_3"
             @test JuliaLibWrapping.mangle_python!(typedict, 3, typeinfo) == "Foo_4"
         end
+
+        @testset "sanitize_python_argname" begin
+            sanitize = JuliaLibWrapping.sanitize_python_argname
+            # Heterogeneous tuples (issue #21): juliac emits Tuple{Int32,Float64}
+            # as a struct with fields named "1", "2" — leading digits are illegal
+            # Python identifiers, so the emitter must prefix an underscore.
+            @test sanitize("1") == "_1"
+            @test sanitize("2") == "_2"
+            # Uniqueness still applies after the digit prefix.
+            seen = Set{String}()
+            @test sanitize("1", seen) == "_1"
+            @test sanitize("1", seen) == "_12"
+            # Existing behaviors still hold.
+            @test sanitize("name!") == "name"
+            @test sanitize("") == "_"
+            @test sanitize("class") == "class_"
+        end
     end
 
     @testset "cvector_struct_info" begin


### PR DESCRIPTION
## Summary

- `sanitize_python_argname` now prepends `_` when the sanitized name starts with a digit, so juliac-emitted tuple fields named `"1"`, `"2"`, … land as valid Python identifiers (`_1`, `_2`, …).
- Without this, a heterogeneous tuple like `Tuple{Int32, Float64}` embedded in a `@ccallable` struct misses the homogeneous-array path in `tuple_struct_info` and falls into the normal `Structure` emission, producing syntactically invalid `_lowlevel.py`.

This is part 1 of #21. Part 2 — promoting fixed-size buffers to a first-class `"array"` kind in the ABI JSON — is a juliac-side change and is left for a follow-up; the issue stays open.

## Test plan

- [x] New `sanitize_python_argname` testset covering digit-prefix munging, uniqueness interaction (`"1"`, `"1"` → `"_1"`, `"_12"`), and regression coverage for existing behaviors (special chars → strip, empty → `"_"`, keyword → `"class_"`).
- [x] Full suite: 286 / 286 pass under `julia +rc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)