### PR TITLE
Document and detect multiple JLW libraries

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -100,6 +100,36 @@ for the current MVP — `pyproject.toml` builds a generic sdist/wheel and
 the developer is responsible for any platform tagging the distribution
 target requires.
 
+## Multiple wrapped libraries in one process
+
+One JLW-wrapped library per Python process is the supported configuration.
+If your users need to combine two Julia libraries, compile them as a single
+`juliac` library that exports both APIs.
+
+The reason is that `juliac` libraries embed `libjulia` as a runtime
+dependency, and the Julia runtime is not designed to coexist with another
+copy of itself in the same process. With the default bundle layout each
+wheel ships its own `bundle/lib/libjulia.so.1.13`, but the dynamic linker
+satisfies the second library's `DT_NEEDED libjulia.so.1.13` with the first
+library's already-loaded copy — first one wins. That silently "works" only
+when both libraries were built against byte-compatible Julia versions and
+their sysimages don't collide on global runtime state; mismatched versions
+may crash or miscompute.
+
+Passing `privatize = true` to [`build_library`](@ref) salts each bundle's
+`libjulia` with a random SONAME prefix so the dynamic linker maps both
+copies independently. That removes the silent-sharing footgun at the
+linker layer, but two Julia runtimes in one process — independent GC root
+sets, two thread pools, two BLAS trampoline initializations, two signal
+handler registrations — is itself untested territory. We have no evidence
+the combination is robust.
+
+To make the situation loud rather than silent, every generated
+`_lowlevel.py` records its package name on a process-global sentinel
+(`sys._jlw_loaded_packages`) at import time and emits a `RuntimeWarning`
+when a second JLW-wrapped package is imported into the same process.
+Tracked as [issue #28](https://github.com/JuliaInterop/JuliaLibWrapping.jl/issues/28).
+
 ## Two-tier Python output
 
 `write_wrapper(PythonTarget, …)` emits three files into the generated package

--- a/src/python.jl
+++ b/src/python.jl
@@ -651,6 +651,34 @@ function _write_bindings(f::IO, dest::PythonTarget, abi_info::ABIInfo,
     println(f, "_lib = ctypes.CDLL(_resolve_library_path())")
     println(f)
 
+    # Detect a second JLW-wrapped library being loaded into the same process.
+    # The default bundle layout makes the dynamic linker satisfy the second
+    # library's `libjulia` dependency with the first library's already-loaded
+    # copy (first one wins, byte-compatible Julia versions assumed); with
+    # `privatize = True` each library gets its own libjulia but two Julia
+    # runtimes in one process is itself untested. See issue #28.
+    println(f, "_JLW_LOADED_ATTR = \"_jlw_loaded_packages\"")
+    println(f, "_jlw_loaded = getattr(sys, _JLW_LOADED_ATTR, None)")
+    println(f, "if _jlw_loaded is None:")
+    println(f, "    _jlw_loaded = set()")
+    println(f, "    setattr(sys, _JLW_LOADED_ATTR, _jlw_loaded)")
+    println(f, "_jlw_this_pkg = __package__ or __name__")
+    println(f, "if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:")
+    println(f, "    import warnings")
+    println(f, "    warnings.warn(")
+    println(f, "        f\"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a \"")
+    println(f, "        f\"process that already loaded {sorted(_jlw_loaded)!r}. Multiple \"")
+    println(f, "        \"JLW-wrapped libraries in one process is not a supported \"")
+    println(f, "        \"configuration: the dynamic linker silently shares a single \"")
+    println(f, "        \"libjulia across them, which assumes byte-compatible Julia \"")
+    println(f, "        \"versions and shares one Julia runtime. See the JuliaLibWrapping \"")
+    println(f, "        \"docs section on multiple wrapped libraries in one process.\",")
+    println(f, "        RuntimeWarning,")
+    println(f, "        stacklevel=2,")
+    println(f, "    )")
+    println(f, "_jlw_loaded.add(_jlw_this_pkg)")
+    println(f)
+
     if needs_jlwerror
         # Implements issue #15: error-propagation convention via JLWStatus.
         print(f, JLWERROR_DEFINITION)

--- a/test/expected_cmatrix_lowlevel.py
+++ b/test/expected_cmatrix_lowlevel.py
@@ -32,6 +32,27 @@ def _resolve_library_path():
 
 _lib = ctypes.CDLL(_resolve_library_path())
 
+_JLW_LOADED_ATTR = "_jlw_loaded_packages"
+_jlw_loaded = getattr(sys, _JLW_LOADED_ATTR, None)
+if _jlw_loaded is None:
+    _jlw_loaded = set()
+    setattr(sys, _JLW_LOADED_ATTR, _jlw_loaded)
+_jlw_this_pkg = __package__ or __name__
+if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
+    import warnings
+    warnings.warn(
+        f"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a "
+        f"process that already loaded {sorted(_jlw_loaded)!r}. Multiple "
+        "JLW-wrapped libraries in one process is not a supported "
+        "configuration: the dynamic linker silently shares a single "
+        "libjulia across them, which assumes byte-compatible Julia "
+        "versions and shares one Julia runtime. See the JuliaLibWrapping "
+        "docs section on multiple wrapped libraries in one process.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+_jlw_loaded.add(_jlw_this_pkg)
+
 class CMatrix_Float64(ctypes.Structure):
     _fields_ = [
         ("rows", ctypes.c_int32),

--- a/test/expected_cstring_lowlevel.py
+++ b/test/expected_cstring_lowlevel.py
@@ -31,6 +31,27 @@ def _resolve_library_path():
 
 _lib = ctypes.CDLL(_resolve_library_path())
 
+_JLW_LOADED_ATTR = "_jlw_loaded_packages"
+_jlw_loaded = getattr(sys, _JLW_LOADED_ATTR, None)
+if _jlw_loaded is None:
+    _jlw_loaded = set()
+    setattr(sys, _JLW_LOADED_ATTR, _jlw_loaded)
+_jlw_this_pkg = __package__ or __name__
+if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
+    import warnings
+    warnings.warn(
+        f"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a "
+        f"process that already loaded {sorted(_jlw_loaded)!r}. Multiple "
+        "JLW-wrapped libraries in one process is not a supported "
+        "configuration: the dynamic linker silently shares a single "
+        "libjulia across them, which assumes byte-compatible Julia "
+        "versions and shares one Julia runtime. See the JuliaLibWrapping "
+        "docs section on multiple wrapped libraries in one process.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+_jlw_loaded.add(_jlw_this_pkg)
+
 class CString(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int32),

--- a/test/expected_libsimple_lowlevel.py
+++ b/test/expected_libsimple_lowlevel.py
@@ -32,6 +32,27 @@ def _resolve_library_path():
 
 _lib = ctypes.CDLL(_resolve_library_path())
 
+_JLW_LOADED_ATTR = "_jlw_loaded_packages"
+_jlw_loaded = getattr(sys, _JLW_LOADED_ATTR, None)
+if _jlw_loaded is None:
+    _jlw_loaded = set()
+    setattr(sys, _JLW_LOADED_ATTR, _jlw_loaded)
+_jlw_this_pkg = __package__ or __name__
+if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
+    import warnings
+    warnings.warn(
+        f"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a "
+        f"process that already loaded {sorted(_jlw_loaded)!r}. Multiple "
+        "JLW-wrapped libraries in one process is not a supported "
+        "configuration: the dynamic linker silently shares a single "
+        "libjulia across them, which assumes byte-compatible Julia "
+        "versions and shares one Julia runtime. See the JuliaLibWrapping "
+        "docs section on multiple wrapped libraries in one process.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+_jlw_loaded.add(_jlw_this_pkg)
+
 # Forward declarations for recursive types
 class CTree_Float64(ctypes.Structure):
     pass

--- a/test/expected_rawptr_lowlevel.py
+++ b/test/expected_rawptr_lowlevel.py
@@ -31,6 +31,27 @@ def _resolve_library_path():
 
 _lib = ctypes.CDLL(_resolve_library_path())
 
+_JLW_LOADED_ATTR = "_jlw_loaded_packages"
+_jlw_loaded = getattr(sys, _JLW_LOADED_ATTR, None)
+if _jlw_loaded is None:
+    _jlw_loaded = set()
+    setattr(sys, _JLW_LOADED_ATTR, _jlw_loaded)
+_jlw_this_pkg = __package__ or __name__
+if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
+    import warnings
+    warnings.warn(
+        f"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a "
+        f"process that already loaded {sorted(_jlw_loaded)!r}. Multiple "
+        "JLW-wrapped libraries in one process is not a supported "
+        "configuration: the dynamic linker silently shares a single "
+        "libjulia across them, which assumes byte-compatible Julia "
+        "versions and shares one Julia runtime. See the JuliaLibWrapping "
+        "docs section on multiple wrapped libraries in one process.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+_jlw_loaded.add(_jlw_this_pkg)
+
 _lib.sum_doubles.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int64]
 _lib.sum_doubles.restype = ctypes.c_double
 def sum_doubles(data, n):


### PR DESCRIPTION
Loading two JuliaLibWrapping-wrapped libraries into a single Python process is not a supported configuration: the dynamic linker silently shares one libjulia across them (first one wins), and even `privatize` only isolates them at the dlopen layer, and we should be frank with users that two Julia runtimes in one process is untested territory.

Document the limitation in `docs/src/index.md` and have every generated `_lowlevel.py` record its package on `sys._jlw_loaded_packages` at import, raising a `RuntimeWarning` when a second JLW package is loaded so the situation is loud rather than silent.

See #28.