### PR TITLE
Deploy and split the docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,34 +45,27 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-  # docs:
-  #   name: Documentation
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: write # needed to allow julia-actions/cache to proactively delete old caches that it has created
-  #     contents: write
-  #     statuses: write
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: julia-actions/setup-julia@v2
-  #       with:
-  #         version: '1'
-  #     - uses: julia-actions/cache@v2
-  #     - name: Configure doc environment
-  #       shell: julia --project=docs --color=yes {0}
-  #       run: |
-  #         using Pkg
-  #         Pkg.develop(PackageSpec(path=pwd()))
-  #         Pkg.instantiate()
-  #     - uses: julia-actions/julia-buildpkg@v1
-  #     - uses: julia-actions/julia-docdeploy@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-  #     - name: Run doctests
-  #       shell: julia --project=docs --color=yes {0}
-  #       run: |
-  #         using Documenter: DocMeta, doctest
-  #         using JuliaLibWrapping
-  #         DocMeta.setdocmeta!(JuliaLibWrapping, :DocTestSetup, :(using JuliaLibWrapping); recursive=true)
-  #         doctest(JuliaLibWrapping)
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write # needed to allow julia-actions/cache to proactively delete old caches that it has created
+      contents: write
+      statuses: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: 'pre'
+      - uses: julia-actions/cache@v2
+      - name: Configure doc environment
+        shell: julia --project=docs --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,8 +14,11 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "Concepts" => "concepts.md",
         "Error handling" => "error_handling.md",
+        "API reference" => "api.md",
     ],
+    warnonly=[:cross_references],  # CVector/CMatrix live in JLWInterop
 )
 
 deploydocs(;

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,12 @@
+```@meta
+CurrentModule = JuliaLibWrapping
+```
+
+# API reference
+
+```@index
+```
+
+```@autodocs
+Modules = [JuliaLibWrapping]
+```

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -1,0 +1,231 @@
+```@meta
+CurrentModule = JuliaLibWrapping
+```
+
+# Concepts
+
+This page describes the pipeline architecture, the data model that
+flows through it, and the cross-cutting concerns (bundling, runtime
+sharing, two-tier output) that shape the generated wrappers.
+
+## The pipeline
+
+The transformation from a Julia source file to a wrapper package runs
+in three stages with an optional driver in front:
+
+    source.jl
+      │   juliac
+      ▼
+    lib<name>.so + <name>_abi.json
+      │   read_abi_info → parse_abi_info → sort_declarations!
+      ▼
+    ABIInfo (descriptors in dependency order)
+      │   write_wrapper(target, abi_info)
+      ▼
+    .h / Python package
+
+[`build_library`](@ref) chains the whole sequence; the stages are also
+callable individually when you want finer control or are testing the
+emitters against fixture JSON.
+
+## Driving the pipeline
+
+[`build_library`](@ref) runs the full `juliac` → ABI JSON → wrapper
+pipeline in one call:
+
+```julia
+using JuliaLibWrapping
+using JuliaC
+out = mktempdir()
+result = build_library(
+    joinpath(@__DIR__, "src/mylib.jl"),
+    [CTarget(out, "mylib"), PythonTarget(out, "mylib_py", "mylib")];
+    project = @__DIR__,
+    libname = "mylib",
+    libdir  = out,
+)
+```
+
+`build_library` invokes `juliac` to produce the shared library and ABI
+JSON, then applies [`write_wrapper`](@ref) to each target. The supported
+route is [JuliaC.jl](https://github.com/JuliaLang/JuliaC.jl) (a weak
+dependency): load it with `using JuliaC` before calling
+`build_library`. ABI developers who want to try features ahead of
+JuliaC.jl can opt into the unstable in-tree
+`share/julia/juliac/juliac.jl` script by passing `backend = :script`.
+
+Relative `[sources]` paths in the entry project's `Project.toml` are
+rejected up front, because `juliac` relocates the project into a
+temporary directory before compiling.
+
+## The ABI data model
+
+`juliac` assigns every type an integer `type_id`. The JSON file
+contains a flat list of type descriptors keyed by that id, plus a list
+of exported entrypoint methods.
+
+After parsing, an `ABIInfo` carries an `OrderedDict{Int, TypeDesc}` of
+descriptors:
+
+- `PrimitiveTypeDesc` — `Int32`, `Float64`, etc.
+- `StructDesc` — a sequence of `FieldDesc`s referencing other type ids.
+- `PointerDesc` — a pointer to another type id.
+
+and a list of `MethodDesc`s whose `ArgDesc`s likewise reference types
+by id. All cross-references use ids, not names; the descriptors form a
+graph.
+
+`sort_declarations!` is the conceptual core of the import stage. C
+requires a type to be defined before use, so the dict must be sorted
+into dependency order. The implementation builds the type-dependency
+graph (Graphs.jl), finds strongly-connected components for
+mutually-recursive types, drops the pointer edges within those SCCs to
+make the graph acyclic, topologically sorts the result, and returns
+the `forward_declared::BitSet` that the C emitter uses to insert
+forward declarations.
+
+## Emission targets
+
+`AbstractTarget` is the extension point for new output formats. Each
+concrete target is a configuration struct passed to
+`write_wrapper(target, abi_info)`. Two backends ship today:
+
+- [`CTarget`](@ref) — emits a single `.h` header. Primitive types map
+  through a fixed `ctypes` table; non-primitive names go through
+  `mangle_c!` to produce C-safe identifiers (memoized in a per-target
+  `typedict`, with numeric suffixing on collision). Pointer types are
+  emitted inline as `T*` rather than as separate typedefs.
+- [`PythonTarget`](@ref) — emits a Python `ctypes` package with the
+  two-tier layout described below.
+
+Adding a new target means defining a struct subtype of `AbstractTarget`
+and a method `write_wrapper(::YourTarget, ::ABIInfo)` that walks the
+sorted descriptors and emits whatever your target language requires.
+
+## Two-tier Python output
+
+`write_wrapper(PythonTarget, …)` emits three files into the generated
+package directory:
+
+- `_lowlevel.py` — the mechanical `ctypes` bindings: `Structure`
+  subclasses and functions carrying the raw C signature. **Always
+  regenerated** on every `write_wrapper` call.
+- `_facade.py` — the idiomatic surface that consumers of the package
+  actually call. JuliaLibWrapping writes this **once** as a starter
+  façade, then never touches it again. The starter is *not* a blank
+  stub: any entrypoint whose arguments and return are all recognized —
+  primitive scalars, `CVector{T}`, `CMatrix{T}`, `CString`, or a
+  direct `JLWStatus` return — is auto-wrapped to accept and return
+  idiomatic Python objects (numpy arrays, `str`). Entrypoints with a
+  raw pointer, an unrecognized struct, or an embedded `JLWStatus`
+  field are re-exported from `_lowlevel` and tagged with a `# TODO:
+  hand-wrap` comment naming the obstacle. Edit anything freely; to
+  regenerate (for example, after adding new entrypoints), delete the
+  file and re-run `write_wrapper`.
+- `__init__.py` — always regenerated; re-exports from `_facade` so the
+  façade is the package's public surface.
+
+The intent is that scientific users of the wrapped library import the
+package top-level and see only the façade. The mechanical layer
+remains available under `pkg._lowlevel` for power users who need it.
+
+Recognition of `CVector` / `CMatrix` / `CString` / `JLWStatus` is
+**structural** — by struct name plus field shape — so authors who
+copy-paste a compatible definition into their own library still get
+the same wrapper behavior.
+[JLWInterop](https://github.com/JuliaInterop/JuliaLibWrapping.jl/tree/main/JLWInterop)
+is the canonical source of these definitions; using it keeps libraries
+from drifting out of structural compatibility.
+
+## Bundling for distribution
+
+A `juliac`-compiled `.so` is not self-contained: it links against
+`libjulia`, depends on a sysimage, and pulls in stdlibs and JLL
+artifacts. A Python user who runs `pip install` does not have any of
+that on their machine, so the default flat `lib<name>.so`-next-to-the-
+package layout fails at import time for the actual target audience.
+
+Pass `bundle = true` to [`build_library`](@ref) to also assemble the
+full runtime closure (the `juliac --bundle` layout) and copy it into
+every [`PythonTarget`](@ref)'s package:
+
+```julia
+using JuliaLibWrapping, JuliaC
+out = mktempdir()
+result = build_library(
+    joinpath(@__DIR__, "src/mylib.jl"),
+    [PythonTarget(out, "mylib_py", "mylib"; bundle_subdir = "bundle")];
+    project = @__DIR__,
+    libname = "mylib",
+    libdir  = out,
+    bundle  = true,
+)
+```
+
+The resulting package layout is
+
+    out/mylib_py/
+    ├── __init__.py
+    ├── _facade.py
+    ├── _lowlevel.py
+    ├── pyproject.toml
+    └── bundle/
+        ├── lib/
+        │   ├── libmylib.so       # user lib, RUNPATH=$ORIGIN/[/julia]
+        │   ├── libjulia.so.1.13
+        │   └── julia/…           # libjulia-internal, stdlibs, BLAS, …
+        └── artifacts/…
+
+The generated `_lowlevel.py` loader searches `bundle/lib/` before the
+package root, so the `RUNPATH` baked in at link time resolves
+`libjulia` and friends from inside the wheel — no `LD_LIBRARY_PATH`
+and no Julia install required on the user's machine. A developer who
+instead drops a bare `lib<name>.so` next to the package (without
+bundling) still works: the loader falls back to the flat layout.
+
+`pip install ./out/mylib_py` from a clean virtualenv on a machine
+without a system Julia is the right manual check.
+
+`bundle = true` requires the `:juliac` backend and that each
+[`PythonTarget`](@ref) declare a `bundle_subdir`. The bundle itself is
+multi-hundred-MB (mostly `libLLVM` and `libjulia-codegen`), so it is
+opt-in. Pass `privatize = true` to additionally salt the bundled
+`libjulia` files with a random prefix, avoiding any chance of collision
+with a system `libjulia` loaded by the same process.
+
+Wheel-level packaging (platform tags, `manylinux` audit) is out of
+scope for the current MVP — `pyproject.toml` builds a generic
+sdist/wheel and the developer is responsible for any platform tagging
+the distribution target requires.
+
+## Multiple wrapped libraries in one process
+
+One JLW-wrapped library per Python process is the supported
+configuration. If your users need to combine two Julia libraries,
+compile them as a single `juliac` library that exports both APIs.
+
+The reason is that `juliac` libraries embed `libjulia` as a runtime
+dependency, and the Julia runtime is not designed to coexist with
+another copy of itself in the same process. With the default bundle
+layout each wheel ships its own `bundle/lib/libjulia.so.1.13`, but the
+dynamic linker satisfies the second library's `DT_NEEDED
+libjulia.so.1.13` with the first library's already-loaded copy — first
+one wins. That silently "works" only when both libraries were built
+against byte-compatible Julia versions and their sysimages don't
+collide on global runtime state; mismatched versions may crash or
+miscompute.
+
+Passing `privatize = true` to [`build_library`](@ref) salts each
+bundle's `libjulia` with a random SONAME prefix so the dynamic linker
+maps both copies independently. That removes the silent-sharing
+footgun at the linker layer, but two Julia runtimes in one process —
+independent GC root sets, two thread pools, two BLAS trampoline
+initializations, two signal handler registrations — is itself
+untested territory. We have no evidence the combination is robust.
+
+To make the situation loud rather than silent, every generated
+`_lowlevel.py` records its package name on a process-global sentinel
+(`sys._jlw_loaded_packages`) at import time and emits a
+`RuntimeWarning` when a second JLW-wrapped package is imported into
+the same process. Tracked as
+[issue #28](https://github.com/JuliaInterop/JuliaLibWrapping.jl/issues/28).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,161 +4,46 @@ CurrentModule = JuliaLibWrapping
 
 # JuliaLibWrapping
 
-Documentation for [JuliaLibWrapping](https://github.com/JuliaInterop/JuliaLibWrapping.jl).
+[JuliaLibWrapping](https://github.com/JuliaInterop/JuliaLibWrapping.jl)
+generates C headers and Python `ctypes` bindings for shared libraries
+compiled from Julia by [`juliac`](https://github.com/JuliaLang/JuliaC.jl).
+It turns the ABI metadata that `juliac` emits into wrappers that let
+non-Julia programs call the compiled library as if it were any other
+native dependency.
 
-See [Error handling](@ref "Error handling across the ABI") for the
-`JLWStatus` convention that lets wrapped libraries surface errors as native
-exceptions in the target language.
+## Who it is for
 
-## Driving the pipeline
+Authors of Julia libraries who want to ship a compiled artifact that
+downstream users — typically C or Python programmers — can consume
+without installing a Julia runtime themselves. The compiled library is
+produced by `juliac`; this package produces the binding code that makes
+it usable from the target language.
 
-[`build_library`](@ref) runs the full `juliac` → ABI JSON → wrapper pipeline
-in one call:
+## The two-tool split
 
-```julia
-using JuliaLibWrapping
-using JuliaC
-out = mktempdir()
-result = build_library(
-    joinpath(@__DIR__, "src/mylib.jl"),
-    [CTarget(out, "mylib"), PythonTarget(out, "mylib_py", "mylib")];
-    project = @__DIR__,
-    libname = "mylib",
-    libdir  = out,
-)
-```
+The pipeline is split deliberately across two packages:
 
-`build_library` invokes `juliac` to produce the shared library and ABI JSON,
-then applies [`write_wrapper`](@ref) to each target. The supported route is
-[JuliaC.jl](https://github.com/JuliaLang/JuliaC.jl) (a weak dependency): load
-it with `using JuliaC` before calling `build_library`. ABI developers who want
-to try features ahead of JuliaC.jl can opt into the unstable in-tree
-`share/julia/juliac/juliac.jl` script by passing `backend = :script`.
+    juliac / JuliaC.jl --emits--> JSON ABI-info file --consumed by--> JuliaLibWrapping --emits--> .h / Python package
 
-Relative `[sources]` paths in the entry project's `Project.toml` are rejected
-up front, because `juliac` relocates the project into a temporary directory
-before compiling.
+[JuliaC.jl](https://github.com/JuliaLang/JuliaC.jl) compiles the shared
+library and emits a JSON file describing its ABI, but does not generate
+wrappers. JuliaLibWrapping consumes that JSON and emits the wrappers.
+Coupling between the two repos is the JSON format alone.
 
-## Bundling for distribution
+[`build_library`](@ref) runs both halves in one call when JuliaC.jl is
+loaded; see [Concepts](@ref) for the pipeline architecture and the
+bundling, multi-library, and two-tier output stories.
 
-A `juliac`-compiled `.so` is not self-contained: it links against
-`libjulia`, depends on a sysimage, and pulls in stdlibs and JLL artifacts.
-A Python user who runs `pip install` does not have any of that on their
-machine, so the default flat `lib<name>.so`-next-to-the-package layout
-fails at import time for the actual target audience.
+## Where to go next
 
-Pass `bundle = true` to [`build_library`](@ref) to also assemble the full
-runtime closure (the `juliac --bundle` layout) and copy it into every
-[`PythonTarget`](@ref)'s package:
-
-```julia
-using JuliaLibWrapping, JuliaC
-out = mktempdir()
-result = build_library(
-    joinpath(@__DIR__, "src/mylib.jl"),
-    [PythonTarget(out, "mylib_py", "mylib"; bundle_subdir = "bundle")];
-    project = @__DIR__,
-    libname = "mylib",
-    libdir  = out,
-    bundle  = true,
-)
-```
-
-The resulting package layout is
-
-    out/mylib_py/
-    ├── __init__.py
-    ├── _facade.py
-    ├── _lowlevel.py
-    ├── pyproject.toml
-    └── bundle/
-        ├── lib/
-        │   ├── libmylib.so       # user lib, RUNPATH=$ORIGIN/[/julia]
-        │   ├── libjulia.so.1.13
-        │   └── julia/…           # libjulia-internal, stdlibs, BLAS, …
-        └── artifacts/…
-
-The generated `_lowlevel.py` loader searches `bundle/lib/` before the
-package root, so the `RUNPATH` baked in at link time resolves `libjulia`
-and friends from inside the wheel — no `LD_LIBRARY_PATH` and no Julia
-install required on the user's machine. A developer who instead drops a
-bare `lib<name>.so` next to the package (without bundling) still works:
-the loader falls back to the flat layout.
-
-`pip install ./out/mylib_py` from a clean virtualenv on a machine
-without a system Julia is the right manual check.
-
-`bundle = true` requires the `:juliac` backend and that each
-[`PythonTarget`](@ref) declare a `bundle_subdir`. The bundle itself is
-multi-hundred-MB (mostly `libLLVM` and `libjulia-codegen`), so it is
-opt-in. Pass `privatize = true` to additionally salt the bundled
-`libjulia` files with a random prefix, avoiding any chance of collision
-with a system `libjulia` loaded by the same process.
-
-Wheel-level packaging (platform tags, `manylinux` audit) is out of scope
-for the current MVP — `pyproject.toml` builds a generic sdist/wheel and
-the developer is responsible for any platform tagging the distribution
-target requires.
-
-## Multiple wrapped libraries in one process
-
-One JLW-wrapped library per Python process is the supported configuration.
-If your users need to combine two Julia libraries, compile them as a single
-`juliac` library that exports both APIs.
-
-The reason is that `juliac` libraries embed `libjulia` as a runtime
-dependency, and the Julia runtime is not designed to coexist with another
-copy of itself in the same process. With the default bundle layout each
-wheel ships its own `bundle/lib/libjulia.so.1.13`, but the dynamic linker
-satisfies the second library's `DT_NEEDED libjulia.so.1.13` with the first
-library's already-loaded copy — first one wins. That silently "works" only
-when both libraries were built against byte-compatible Julia versions and
-their sysimages don't collide on global runtime state; mismatched versions
-may crash or miscompute.
-
-Passing `privatize = true` to [`build_library`](@ref) salts each bundle's
-`libjulia` with a random SONAME prefix so the dynamic linker maps both
-copies independently. That removes the silent-sharing footgun at the
-linker layer, but two Julia runtimes in one process — independent GC root
-sets, two thread pools, two BLAS trampoline initializations, two signal
-handler registrations — is itself untested territory. We have no evidence
-the combination is robust.
-
-To make the situation loud rather than silent, every generated
-`_lowlevel.py` records its package name on a process-global sentinel
-(`sys._jlw_loaded_packages`) at import time and emits a `RuntimeWarning`
-when a second JLW-wrapped package is imported into the same process.
-Tracked as [issue #28](https://github.com/JuliaInterop/JuliaLibWrapping.jl/issues/28).
-
-## Two-tier Python output
-
-`write_wrapper(PythonTarget, …)` emits three files into the generated package
-directory:
-
-- `_lowlevel.py` — the mechanical `ctypes` bindings: `Structure` subclasses
-  and functions carrying the raw C signature. **Always regenerated** on
-  every `write_wrapper` call.
-- `_facade.py` — the idiomatic surface that consumers of the package
-  actually call. JuliaLibWrapping writes this **once** as a starter façade,
-  then never touches it again. The starter is *not* a blank stub: any
-  entrypoint whose arguments and return are all recognized — primitive
-  scalars, `CVector{T}`, `CMatrix{T}`, `CString`, or a direct `JLWStatus`
-  return — is auto-wrapped to accept and return idiomatic Python objects
-  (numpy arrays, `str`). Entrypoints with a raw pointer, an unrecognized
-  struct, or an embedded `JLWStatus` field are re-exported from `_lowlevel`
-  and tagged with a `# TODO: hand-wrap` comment naming the obstacle.
-  Edit anything freely; to regenerate (for example, after adding new
-  entrypoints), delete the file and re-run `write_wrapper`.
-- `__init__.py` — always regenerated; re-exports from `_facade` so the
-  façade is the package's public surface.
-
-The intent is that scientific users of the wrapped library import the
-package top-level and see only the façade. The mechanical layer remains
-available under `pkg._lowlevel` for power users who need it.
-
-```@index
-```
-
-```@autodocs
-Modules = [JuliaLibWrapping]
-```
+- [Concepts](@ref) — the pipeline, the ABI data model, the extension
+  point for new target languages, and the runtime-closure / bundling
+  story.
+- [Error handling across the ABI](@ref) — the `JLWStatus` convention
+  that lets wrapped libraries surface errors as native exceptions in
+  the target language.
+- [API reference](@ref) — generated docstrings for the public API.
+- [JLWInterop](https://github.com/JuliaInterop/JuliaLibWrapping.jl/tree/main/JLWInterop)
+  — the dependency-free vocabulary package (`CVector`, `CMatrix`,
+  `CString`, `JLWStatus`) that compiled libraries and the Python
+  emitter both speak.

--- a/src/JuliaLibWrapping.jl
+++ b/src/JuliaLibWrapping.jl
@@ -9,6 +9,19 @@ export AbstractTarget, CTarget, PythonTarget, ABIInfo
 
 include("abi_import.jl")
 
+"""
+    AbstractTarget
+
+Supertype of wrapper-emission targets. Each concrete subtype is a
+configuration struct describing where and how to emit one output
+language's bindings; a corresponding [`write_wrapper`](@ref) method
+consumes that configuration plus an [`ABIInfo`](@ref) and writes the
+files.
+
+Ships today: [`CTarget`](@ref) for a C header, [`PythonTarget`](@ref)
+for a Python `ctypes` package. New languages are added by defining a
+subtype and a `write_wrapper` method for it.
+"""
 abstract type AbstractTarget end
 
 include("c.jl")

--- a/src/c.jl
+++ b/src/c.jl
@@ -1,3 +1,17 @@
+"""
+    CTarget(dir, headerbase)
+
+Output configuration for a C header. [`write_wrapper`](@ref) writes a
+single file `joinpath(dir, headerbase * ".h")` containing typedefs for
+every struct in the ABI and `extern` declarations for every entrypoint.
+
+Only the primitive Julia types listed in the emitter's `ctypes` table
+have a direct C mapping; an ABI referencing any other primitive raises
+an error. Pointer types are emitted inline as `T*` rather than as
+separate typedefs. Non-C-safe identifiers are scrubbed by
+[`sanitize_for_c`](@ref) and disambiguated with a numeric suffix on
+collision.
+"""
 struct CTarget <: AbstractTarget
     dir::String
     headerbase::String
@@ -13,6 +27,17 @@ function unwrap_pointer_type(type_id::Int, typeinfo::OrderedDict{Int, TypeDesc})
     end
     return type_id
 end
+
+"""
+    write_wrapper(target::AbstractTarget, abi_info::ABIInfo)
+
+Emit wrapper source files for `abi_info` into the location described by
+`target`. The methods that ship are dispatched on [`CTarget`](@ref) (one
+`.h` file) and [`PythonTarget`](@ref) (a Python `ctypes` package
+directory). Add a method for a new [`AbstractTarget`](@ref) subtype to
+support another output language.
+"""
+function write_wrapper end
 
 function write_wrapper(dest::CTarget, abi_info::ABIInfo)
     (; entrypoints, typeinfo, forward_declared) = abi_info
@@ -116,6 +141,16 @@ const ctypes = Dict{String, String}(
     "Csize_t" => "size_t",
 )
 
+"""
+    sanitize_for_c(str) -> String
+
+Return `str` with all non-alphanumeric (non-underscore) characters
+replaced by `_`, leading/trailing underscores stripped, and runs of
+underscores collapsed. Used to coerce Julia identifiers and type names
+into valid C tokens. Two distinct inputs may collide; callers that need
+uniqueness (e.g. `mangle_c!`) suffix the result with a numeric
+disambiguator.
+"""
 function sanitize_for_c(str::AbstractString)
     # Replace any non alphanumeric characters with '_'
     str = replace(str, r"[^a-zA-Z0-9_]" => "_")

--- a/src/python.jl
+++ b/src/python.jl
@@ -147,6 +147,15 @@ function mangle_python!(typedict::Dict{Int, String}, type_id::Int,
     return mangled
 end
 
+"""
+    numpy_dtypes :: Dict{String, String}
+
+Map from Julia primitive type name to the corresponding numpy dtype
+string. Used by the Python façade emitter to decide which pointer
+element types can be exposed as numpy arrays in `CVector` / `CMatrix`
+helpers; primitives absent from this table (notably `Bool`, the
+platform-aliased C ints) are not auto-wrapped.
+"""
 const numpy_dtypes = Dict{String, String}(
     "Int8" => "int8", "Int16" => "int16", "Int32" => "int32", "Int64" => "int64",
     "UInt8" => "uint8", "UInt16" => "uint16", "UInt32" => "uint32", "UInt64" => "uint64",


### PR DESCRIPTION
- doc build and deployment was commented-out; re-enable it
- split the docs into a true landing page, a concepts page, and an API page