### PR TITLE
Add a JLWInterop docs page co-hosted in the main build

### DIFF
--- a/JLWInterop/src/JLWInterop.jl
+++ b/JLWInterop/src/JLWInterop.jl
@@ -20,6 +20,14 @@ module JLWInterop
 export JLWStatus, jlw_ok, jlw_error
 export CVector, CMatrix, CString
 
+"""
+    JLW_MESSAGE_BYTES
+
+The fixed size, in bytes, of the inline `message` buffer inside
+[`JLWStatus`](@ref). Sets the maximum message length an error can
+carry across the ABI; longer strings passed to [`jlw_error`](@ref) are
+truncated to `JLW_MESSAGE_BYTES - 1` bytes plus a terminating NUL.
+"""
 const JLW_MESSAGE_BYTES = 256
 
 """

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+JLWInterop = "65e54657-ed21-41a3-96db-71ab7fa6d94b"
 JuliaLibWrapping = "d61f35a8-f6af-436f-bc10-cee6b101f7bd"
+
+[sources]
+JLWInterop = {path = "../JLWInterop"}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,10 +1,12 @@
 using JuliaLibWrapping
+using JLWInterop
 using Documenter
 
 DocMeta.setdocmeta!(JuliaLibWrapping, :DocTestSetup, :(using JuliaLibWrapping); recursive=true)
+DocMeta.setdocmeta!(JLWInterop, :DocTestSetup, :(using JLWInterop); recursive=true)
 
 makedocs(;
-    modules=[JuliaLibWrapping],
+    modules=[JuliaLibWrapping, JLWInterop],
     authors="Tim Holy <tim.holy@gmail.com> and contributors",
     sitename="JuliaLibWrapping.jl",
     format=Documenter.HTML(;
@@ -15,10 +17,10 @@ makedocs(;
     pages=[
         "Home" => "index.md",
         "Concepts" => "concepts.md",
+        "JLWInterop" => "jlwinterop.md",
         "Error handling" => "error_handling.md",
         "API reference" => "api.md",
     ],
-    warnonly=[:cross_references],  # CVector/CMatrix live in JLWInterop
 )
 
 deploydocs(;

--- a/docs/src/error_handling.md
+++ b/docs/src/error_handling.md
@@ -7,7 +7,7 @@ generated wrappers can translate them into native exceptions.
 
 ## The `JLWStatus` convention
 
-The canonical status struct is defined in the [JLWInterop](https://github.com/JuliaInterop/JuliaLibWrapping.jl/tree/main/JLWInterop)
+The canonical status struct is defined in the [JLWInterop](@ref)
 subdir package and has the following shape:
 
 ```julia

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,11 +39,10 @@ bundling, multi-library, and two-tier output stories.
 - [Concepts](@ref) — the pipeline, the ABI data model, the extension
   point for new target languages, and the runtime-closure / bundling
   story.
+- [JLWInterop](@ref) — the dependency-free vocabulary package
+  (`CVector`, `CMatrix`, `CString`, `JLWStatus`) that compiled
+  libraries and the Python emitter both speak.
 - [Error handling across the ABI](@ref) — the `JLWStatus` convention
   that lets wrapped libraries surface errors as native exceptions in
   the target language.
 - [API reference](@ref) — generated docstrings for the public API.
-- [JLWInterop](https://github.com/JuliaInterop/JuliaLibWrapping.jl/tree/main/JLWInterop)
-  — the dependency-free vocabulary package (`CVector`, `CMatrix`,
-  `CString`, `JLWStatus`) that compiled libraries and the Python
-  emitter both speak.

--- a/docs/src/jlwinterop.md
+++ b/docs/src/jlwinterop.md
@@ -1,0 +1,122 @@
+```@meta
+CurrentModule = JLWInterop
+```
+
+# JLWInterop
+
+```@docs
+JLWInterop
+```
+
+## Ownership and layout discipline
+
+Every type in this package holds a raw pointer and **does not own**
+the underlying storage. The caller that allocated the buffer is
+responsible for keeping it alive for the duration of any call that
+sees it, and for freeing it afterward. In exchange, every type is
+`isbits` (when the element type is), is `juliac --trim`-friendly,
+and crosses a `@ccallable` boundary without heap allocation.
+
+The [JuliaLibWrapping](@ref) Python emitter recognizes these types
+**structurally** — by struct name plus field shape — so an author
+who copy-pastes a compatible definition into their own library gets
+the same wrapper behavior. Depending on `JLWInterop` is the way to
+keep the definitions from drifting across libraries.
+
+## `JLWStatus` — in-band error reporting
+
+A library that needs to surface errors to its caller (rather than
+abort the process) returns either a `JLWStatus` directly, or a struct
+that contains a `JLWStatus` field. `code == 0` is success; any
+non-zero value is an error code the library defines. `message` is a
+fixed-size UTF-8 buffer, null-terminated within the buffer.
+
+The buffer is **inline and fixed-size** ([`JLW_MESSAGE_BYTES`](@ref)
+bytes) on purpose: a `Cstring` or `Ptr{UInt8}` would force a decision
+about who allocates and frees the message, which has no good answer
+under `juliac --trim`. The price is a bounded message length; the
+benefit is that constructing a status performs no heap allocation.
+
+Construct values with the helpers:
+
+```julia
+using JLWInterop
+
+Base.@ccallable function safe_sqrt(x::Float64)::JLWStatus
+    x < 0 && return jlw_error(1, "negative input")
+    return jlw_ok()
+end
+```
+
+See [Error handling across the ABI](@ref) for the full
+library-author-and-Python-caller round trip, including how the
+emitter raises `JLWError` on the Python side.
+
+```@docs
+JLWStatus
+jlw_ok
+jlw_error
+JLW_MESSAGE_BYTES
+```
+
+## `CVector{T}` — 1-D numeric buffer
+
+`CVector{T}` is `(length::Int32, data::Ptr{T})`. The caller owns the
+storage; `CVector` borrows. For primitive numeric `T`, the Python
+emitter generates `from_numpy` / `as_numpy` helpers so a Python
+caller can pass a `numpy.ndarray` directly without copying.
+
+Because `CVector{T} <: AbstractVector{T}`, it participates in
+iteration, broadcasting, `sum`, views, and any function that accepts
+an `AbstractVector{T}` — at zero allocation. `setindex!` is defined
+unconditionally; only call it on storage you know to be writable.
+
+```@docs
+CVector
+```
+
+## `CMatrix{T}` — 2-D numeric buffer (column-major)
+
+`CMatrix{T}` is `(rows::Int32, cols::Int32, data::Ptr{T})`, laid out
+in **column-major** order — the same convention as `Matrix{T}` and
+Fortran, not C. The same ownership discipline as `CVector` applies.
+
+The column-major choice has a sharp consequence on the Python side:
+the generated `from_numpy` helper requires a Fortran-contiguous
+(column-major) array and **rejects** a default row-major `ndarray`.
+Silently treating a row-major buffer as column-major would transpose
+the matrix without warning, which is a footgun no caller asks for.
+Python callers wrapping a default numpy array must `.copy(order='F')`
+first.
+
+`CMatrix{T} <: AbstractMatrix{T}` with `IndexLinear()`, so `m[i, j]`
+reads slot `(j-1)*rows + i` and the type plugs into `LinearAlgebra`
+routines at zero allocation.
+
+```@docs
+CMatrix
+```
+
+## `CString` — length-prefixed UTF-8
+
+`CString` is `(length::Int32, data::Ptr{UInt8})`. It is
+**length-prefixed and not null-terminated** — embedded NUL bytes are
+permitted; `length` is the authoritative size. This makes it distinct
+from `Base.Cstring`, which is null-terminated and forbids embedded
+NULs.
+
+As with the other types, `CString` borrows storage from the caller.
+The Python emitter recognizes it by name plus shape and generates
+`from_str` / `as_str` (UTF-8 round-trip) plus `from_bytes` /
+`as_bytes` (raw bytes) helpers.
+
+`CString <: AbstractString` with `ncodeunits`, `codeunit`, valid-
+position checking, UTF-8 iteration, and a fast byte-level `cmp`.
+Base derives the rest: `length` (character count, distinct from
+`ncodeunits`), `==`, `print`, regex matching, `split`, `replace`, …
+Call `String(s)` to copy the bytes out into a fresh, heap-allocated,
+owning Julia `String`.
+
+```@docs
+CString
+```

--- a/src/python.jl
+++ b/src/python.jl
@@ -293,7 +293,7 @@ reported — only top-level argument types are examined.
 A non-empty result signals an argument that hands the C function a raw memory
 address with no length, ownership, or layout metadata. The Python emitter uses
 this to attach a docstring on the wrapper noting the column-major contract and
-recommending the [`CVector`](@ref) / [`CMatrix`](@ref) vocabulary instead.
+recommending the [`JLWInterop.CVector`](@ref) / [`JLWInterop.CMatrix`](@ref) vocabulary instead.
 """
 function raw_primitive_pointer_args(method::MethodDesc,
                                     typeinfo::OrderedDict{Int, TypeDesc})


### PR DESCRIPTION
JLWInterop is the canonical cross-ABI vocabulary, but had no rendered docs. Add docs/src/jlwinterop.md framed around the library-author perspective ("the types your compiled library uses to talk across the ABI"), with sections for JLWStatus / jlw_ok / jlw_error / JLW_MESSAGE_BYTES, CVector, CMatrix, and CString. Each section leads with ownership and layout discipline before the auto-wrap behavior.

Wire JLWInterop into docs/Project.toml as a path dep and add it to makedocs(modules=…) so its docstrings render. Add a JLW_MESSAGE_BYTES docstring (referenced from JLWStatus) and qualify the CVector / CMatrix @refs inside src/python.jl as JLWInterop.CVector / JLWInterop.CMatrix so they resolve from a JuliaLibWrapping docstring context. With these in place, drop the warnonly=[:cross_references] escape hatch added in the previous commit. Cross-link error_handling.md to the new page.

Fixes #36