### PR TITLE
Add reusable wheel-build workflow for wrapped libraries

### DIFF
--- a/.github/workflows/build-wrappers.yml
+++ b/.github/workflows/build-wrappers.yml
@@ -1,0 +1,152 @@
+# Reusable workflow: build a JuliaLibWrapping-generated Python wheel from a
+# downstream repo's build directory and attach it to a release (or, outside
+# a release event, upload it as a workflow artifact).
+#
+# The build directory must contain `build.jl`, `Project.toml`, `src/`, and a
+# `build-env/Project.toml` — see JuliaLibWrapping's `examples/ols/` for the
+# expected shape. This workflow instantiates `build-env`, runs `build.jl`
+# (which must write a Python package under the resolved output directory),
+# packages that output into a wheel, retags the wheel's platform tag, and
+# (optionally) smoke-tests the installed wheel before publishing it.
+#
+# Minimal caller:
+#
+#   on:
+#     release:
+#       types: [published]
+#   permissions:
+#     contents: write   # required so the workflow can attach wheels to the release
+#   jobs:
+#     wrap:
+#       uses: JuliaInterop/JuliaLibWrapping.jl/.github/workflows/build-wrappers.yml@main
+#       with:
+#         build-dir: build
+#
+# Ref pinning: use `@main` until a tagged JuliaLibWrapping release contains
+# this file, then pin `@<release-tag>` instead — an unpinned `@main` can
+# change under you without notice.
+#
+# Wheel platform tag: `platform-tag` is asserted onto the wheel, not audited
+# against the actual build environment. The default,
+# `manylinux_2_35_x86_64`, claims glibc >= 2.35, matching an
+# `ubuntu-22.04` build; it does NOT match older-glibc targets such as
+# RHEL/Rocky 9. To lower the floor, build inside a container with an older
+# glibc and set `platform-tag`/`runs-on` to match that container.
+
+on:
+  workflow_call:
+    inputs:
+      build-dir:
+        description: >-
+          Directory in the caller repo containing build.jl and build-env/.
+        required: true
+        type: string
+      out-dir:
+        description: >-
+          Directory where build.jl writes the Python package. Defaults to
+          "<build-dir>/out" when empty.
+        required: false
+        type: string
+        default: ''
+      julia-version:
+        description: Julia version passed to julia-actions/setup-julia.
+        required: false
+        type: string
+        default: '1.13'
+      python-version:
+        description: Python version passed to actions/setup-python.
+        required: false
+        type: string
+        default: '3.12'
+      cpu-target:
+        description: >-
+          Julia multi-microarchitecture spec, exported as JULIA_CPU_TARGET
+          for the build step only when non-empty.
+        required: false
+        type: string
+        default: ''
+      platform-tag:
+        description: Wheel platform tag applied to the built wheel.
+        required: false
+        type: string
+        default: 'manylinux_2_35_x86_64'
+      smoke-test:
+        description: >-
+          Path in the caller repo to a Python script run against the
+          installed wheel. Skipped when empty.
+        required: false
+        type: string
+        default: ''
+      runs-on:
+        description: Runner label for the build job.
+        required: false
+        type: string
+        default: 'ubuntu-22.04'
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ inputs.julia-version }}
+          include-all-prereleases: true
+
+      - uses: julia-actions/cache@v2
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Resolve output directory
+        run: |
+          OUT_DIR="${{ inputs.out-dir }}"
+          if [ -z "$OUT_DIR" ]; then
+            OUT_DIR="${{ inputs.build-dir }}/out"
+          fi
+          echo "OUT_DIR=$OUT_DIR" >> "$GITHUB_ENV"
+
+      - name: Set JULIA_CPU_TARGET
+        # An empty exported JULIA_CPU_TARGET would misconfigure juliac, so
+        # only export it when the caller actually supplied a value.
+        if: inputs.cpu-target != ''
+        run: echo "JULIA_CPU_TARGET=${{ inputs.cpu-target }}" >> "$GITHUB_ENV"
+
+      - name: Instantiate build environment
+        run: |
+          julia --project=${{ inputs.build-dir }}/build-env -e 'using Pkg; Pkg.instantiate()'
+
+      - name: Build library and Python package
+        run: |
+          julia --project=${{ inputs.build-dir }}/build-env ${{ inputs.build-dir }}/build.jl
+
+      - name: Install Python packaging tools
+        run: pip install build wheel
+
+      - name: Build wheel
+        run: python -m build --wheel --outdir dist "$OUT_DIR"
+
+      - name: Retag wheel platform
+        run: python -m wheel tags --platform-tag ${{ inputs.platform-tag }} --remove dist/*.whl
+
+      - name: Smoke test wheel
+        if: inputs.smoke-test != ''
+        run: |
+          python -m venv /tmp/jlw-smoke-venv
+          /tmp/jlw-smoke-venv/bin/pip install dist/*.whl
+          /tmp/jlw-smoke-venv/bin/python "${{ inputs.smoke-test }}"
+
+      - name: Upload wheel to release
+        if: github.event_name == 'release'
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.whl --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Upload wheel artifact
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: dist/*.whl

--- a/.github/workflows/test-build-wrappers.yml
+++ b/.github/workflows/test-build-wrappers.yml
@@ -1,0 +1,15 @@
+# Self-test caller for build-wrappers.yml: builds the in-tree `ols` example
+# and smoke-tests the resulting wheel. Run manually (Actions tab -> this
+# workflow -> Run workflow) to validate the reusable workflow end to end.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-ols:
+    uses: ./.github/workflows/build-wrappers.yml
+    with:
+      build-dir: JuliaLibWrapping/examples/ols
+      smoke-test: JuliaLibWrapping/examples/ols/test/smoke.py

--- a/JuliaLibWrapping/examples/ols/test/smoke.py
+++ b/JuliaLibWrapping/examples/ols/test/smoke.py
@@ -1,0 +1,90 @@
+"""Smoke test for the installed `ols_py` wheel.
+
+Run against an already-installed wheel (no pytest dependency):
+
+    pip install dist/*.whl
+    python JuliaLibWrapping/examples/ols/test/smoke.py
+
+Exits nonzero (via AssertionError) on any failure.
+"""
+import numpy as np
+
+import ols_py
+
+
+def _fit(X, y):
+    """Call the low-level `fit` entrypoint; return (coeffs, r_squared).
+
+    `fit`'s return type (`FitResult`) embeds a `JLWStatus`, so
+    JuliaLibWrapping's façade auto-wrapper leaves it as a mechanical
+    re-export: callers pass `CMatrix_Float64`/`CVector_Float64` wrappers
+    directly rather than bare numpy arrays.
+    """
+    n, p = X.shape
+    Xf = np.asfortranarray(X, dtype=np.float64)
+    yf = np.asfortranarray(y, dtype=np.float64)
+    coeffs_buf = np.zeros(p, dtype=np.float64)
+
+    X_c = ols_py.CMatrix_Float64.from_numpy(Xf)
+    y_c = ols_py.CVector_Float64.from_numpy(yf)
+    coeffs_c = ols_py.CVector_Float64.from_numpy(coeffs_buf)
+
+    result = ols_py.fit(X_c, y_c, coeffs_c)
+    assert result.status.code == 0, (
+        result.status.code,
+        bytes(result.status.message).rstrip(b"\x00").decode("utf-8", errors="replace"),
+    )
+    # `coeffs_buf` is caller-allocated storage that `fit` writes into
+    # directly; `result.coeffs` aliases the same buffer.
+    return coeffs_buf.copy(), result.r_squared
+
+
+def test_fit_matches_numpy_lstsq():
+    rng = np.random.default_rng(0)
+    n, p = 20, 3
+    X = np.column_stack([np.ones(n), rng.standard_normal((n, p - 1))])
+    true_coeffs = np.array([1.5, -2.0, 0.75])
+    y = X @ true_coeffs + 0.01 * rng.standard_normal(n)
+
+    coeffs, r_squared = _fit(X, y)
+    expected, *_ = np.linalg.lstsq(X, y, rcond=None)
+
+    assert np.allclose(coeffs, expected, atol=1e-8), (coeffs, expected)
+    assert 0.0 <= r_squared <= 1.0, r_squared
+
+
+def test_predict_matches_matrix_multiply():
+    # `predict`'s args and return (a direct `JLWStatus`) are all recognized
+    # vocabulary types, so the façade auto-wraps it to accept/return plain
+    # numpy arrays; `out` is written in place.
+    rng = np.random.default_rng(1)
+    n, p = 10, 3
+    X = np.asfortranarray(
+        np.column_stack([np.ones(n), rng.standard_normal((n, p - 1))]), dtype=np.float64
+    )
+    coeffs = np.array([0.5, 1.0, -1.0], dtype=np.float64)
+    out = np.zeros(n, dtype=np.float64)
+
+    ols_py.predict(coeffs, X, out)
+
+    expected = X @ coeffs
+    assert np.allclose(out, expected, atol=1e-8), (out, expected)
+
+
+def test_predict_raises_on_length_mismatch():
+    X = np.asfortranarray(np.ones((5, 3)), dtype=np.float64)
+    coeffs = np.ones(2, dtype=np.float64)  # wrong: X has 3 columns
+    out = np.zeros(5, dtype=np.float64)
+    try:
+        ols_py.predict(coeffs, X, out)
+    except ols_py.JLWError as exc:
+        assert exc.code != 0
+    else:
+        raise AssertionError("expected JLWError for mismatched coeffs length")
+
+
+if __name__ == "__main__":
+    test_fit_matches_numpy_lstsq()
+    test_predict_matches_matrix_multiply()
+    test_predict_raises_on_length_mismatch()
+    print("ols_py smoke test passed")


### PR DESCRIPTION
Add a callable workflow that builds JuliaLibWrapping-generated Python packages, retags and smoke-tests their wheels, and publishes them as release assets or workflow artifacts.

Add a manually dispatched end-to-end test using the OLS example.

Fixes #37
