### PR TITLE
Privatize bundled libjulia by default

### DIFF
--- a/JuliaLibWrapping/docs/src/concepts.md
+++ b/JuliaLibWrapping/docs/src/concepts.md
@@ -168,40 +168,46 @@ without a system Julia is the right manual check.
 `bundle = true` requires the `:juliac` backend and that each
 [`PythonTarget`](@ref) declare a `bundle_subdir`. The bundle is several
 hundred megabytes (mostly `libLLVM` and `libjulia-codegen`), so it is
-opt-in. Pass `privatize = true` to additionally salt the bundled
-`libjulia` files with a random prefix, avoiding any chance of collision
-with a system `libjulia` loaded by the same process.
+opt-in. Bundling also salts the bundled `libjulia` files so they cannot
+be satisfied by another `libjulia` already loaded in the process; pass
+`privatize = false` to turn that off — see [Multiple wrapped libraries in
+one process](@ref).
 
 `pyproject.toml` builds a generic sdist/wheel; distributors must supply any
 required platform tags or audits.
 
 ## Multiple wrapped libraries in one process
 
-One JLW-wrapped library per Python process is the supported
-configuration. If your users need to combine two Julia libraries,
-compile them as a single `juliac` library that exports both APIs.
+To use multiple wrapped APIs in one process, either compile them into one
+`juliac` library or build each bundled library with `privatize`, the default
+for bundled builds.
 
-The reason is that `juliac` libraries embed `libjulia` as a runtime
-dependency, and the Julia runtime is not designed to coexist with
-another copy of itself in the same process. With the default bundle
-layout each wheel ships its own `bundle/lib/libjulia.so.1.13`, but the
-dynamic linker satisfies the second library's `DT_NEEDED
-libjulia.so.1.13` with the first library's already-loaded copy. This can work
-only when both libraries were built
-against byte-compatible Julia versions and their sysimages don't
-collide on global runtime state; mismatched versions may crash or
-miscompute.
+`juliac` libraries embed `libjulia` as a runtime dependency. With the
+default bundle layout each wheel ships its own
+`bundle/lib/libjulia.so.1.13`, but the dynamic linker satisfies the second
+library's `DT_NEEDED libjulia.so.1.13` from the first loaded copy. Both
+libraries then address one runtime, but each expects to initialize it. Imports
+succeed because initialization is deferred until the first entrypoint call;
+the first library called works, and the first call into the other aborts the
+process.
 
-Passing `privatize = true` to [`build_library`](@ref) salts each
-bundle's `libjulia` with a random SONAME prefix so the dynamic linker
-maps both copies independently. That removes the linker-level ambiguity,
-but two Julia runtimes in one process —
-independent GC root sets, two thread pools, two BLAS trampoline
-initializations, two signal handler registrations — has not been tested
-and is unsupported.
+`privatize` gives each bundle's `libjulia` and `libjulia-internal` a distinct
+SONAME prefix. The loader then maps each pair independently, and each library
+initializes its own runtime. The runtimes have separate GC state and resolve
+runtime symbols to separate addresses.
 
-To warn about this configuration, every generated
-`_lowlevel.py` records its package name on a process-global sentinel
-(`sys._jlw_loaded_packages`) at import time and emits a
-`RuntimeWarning` when a second JLW-wrapped package is imported into
-the same process.
+Two limits apply to that arrangement:
+
+- **Only the Julia runtime is privatized.** `libopenblas`,
+  `libblastrampoline`, `libgfortran`, and `libunwind` keep their usual names
+  and may be shared. Bundles built by the same Julia contain identical copies;
+  bundles built by different Julia versions have not been tested together.
+- **Each runtime uses its own resources.** Two sysimages, two GC heaps, and
+  two thread pools are resident at once.
+
+This behavior was measured on Linux. macOS and Windows use different library
+resolution rules and have not been tested.
+
+At import time, generated `_lowlevel.py` files record their package names in
+`sys._jlw_loaded_packages`. A non-privatized package emits a `RuntimeWarning`
+if another wrapped package is already present. Privatized packages do not warn.

--- a/JuliaLibWrapping/src/build.jl
+++ b/JuliaLibWrapping/src/build.jl
@@ -12,7 +12,7 @@ const _TRIM_MODES = (:no, :safe, :unsafe, Symbol("unsafe-warn"))
                   trim=:safe, compile_ccallable=true,
                   backend=:auto, verbose=false,
                   bundle=false, bundle_dir=joinpath(libdir, libname*"-bundle"),
-                  privatize=false, cpu_target=nothing)
+                  privatize=bundle, cpu_target=nothing)
 
 Run the full `juliac` → ABI JSON → wrapper pipeline in one call.
 
@@ -71,9 +71,14 @@ declare a `bundle_subdir` (e.g.
 Targets that are not Python (e.g. [`CTarget`](@ref)) are unaffected — C
 consumers manage their own linkage.
 
-`privatize = true` salts the bundled libjulia files with a random prefix so
-they cannot collide with a system libjulia. Off by default; opt in if the
-wrapper might be loaded into a process that also has a different libjulia.
+`privatize` salts the bundled `libjulia` and `libjulia-internal` with a
+distinct SONAME prefix, so the loader cannot satisfy this library's runtime
+dependency from another loaded copy. It defaults to `bundle`. See the manual
+section on multiple wrapped libraries in one process.
+
+Privatization applies to the bundle, so `privatize = true` with
+`bundle = false` is an error rather than a silent no-op. Pass
+`privatize = false` alongside `bundle = true` to opt out.
 
 # CPU target
 
@@ -96,7 +101,7 @@ function build_library(entry::AbstractString,
                        verbose::Bool = false,
                        bundle::Bool = false,
                        bundle_dir::AbstractString = joinpath(libdir, libname * "-bundle"),
-                       privatize::Bool = false,
+                       privatize::Bool = bundle,
                        cpu_target::Union{Nothing,AbstractString} = nothing)
     isfile(entry) || isdir(entry) ||
         throw(ArgumentError("entry not found: $entry"))
@@ -107,6 +112,11 @@ function build_library(entry::AbstractString,
     end
     backend ∈ (:auto, :juliac) ||
         throw(ArgumentError("backend must be :auto or :juliac; got :$backend"))
+    if privatize && !bundle
+        throw(ArgumentError(
+            "privatize = true requires bundle = true: privatization salts the " *
+            "bundled libjulia, and a build without a bundle has none to salt."))
+    end
     if bundle
         for t in targets
             t isa PythonTarget || continue
@@ -146,12 +156,26 @@ function build_library(entry::AbstractString,
 
     target_outputs = Vector{NamedTuple}(undef, length(targets))
     for (i, t) in pairs(targets)
-        write_wrapper(t, abi_info)
+        write_wrapper(_apply_privatization(t, privatize), abi_info)
         target_outputs[i] = (target = typeof(t), dir = t.dir)
     end
 
     return (; library = library_path, abi_path, abi_info, target_outputs,
             backend = :juliac, bundle_dir = bundle ? bundle_dir : nothing)
+end
+
+# Record whether the bundle was privatized so the generated Python can warn
+# when another non-privatized package is already loaded.
+_apply_privatization(t::AbstractTarget, ::Bool) = t
+function _apply_privatization(t::PythonTarget, privatize::Bool)
+    t.privatized == privatize && return t
+    t.privatized && throw(ArgumentError(
+        "PythonTarget for package \"$(t.package_name)\" was constructed with " *
+        "`privatized = true`, but `build_library` was called with `privatize = false`. " *
+        "The generated package would claim a private libjulia it does not have."))
+    return PythonTarget(t.dir, t.package_name, t.library_basename;
+                        bundle_subdir = t.bundle_subdir, version = t.version,
+                        privatized = true)
 end
 
 # Copy the bundle before emitting Python sources.

--- a/JuliaLibWrapping/src/python.jl
+++ b/JuliaLibWrapping/src/python.jl
@@ -1,6 +1,7 @@
 """
     PythonTarget(dir, package_name, library_basename;
-                 bundle_subdir = nothing, version = $(repr(_DEFAULT_PACKAGE_VERSION)))
+                 bundle_subdir = nothing, version = $(repr(_DEFAULT_PACKAGE_VERSION)),
+                 privatized = false)
 
 Output configuration for a Python ctypes-based wrapper package. `dir` is the
 directory into which the package will be written; a sub-directory named
@@ -22,6 +23,11 @@ layout and is the right choice for callers placing the library by hand.
 
 `version` sets the `version` field in the generated `pyproject.toml`. It must
 be PEP 440-compatible; a Julia `Major.Minor.Patch` version string is valid.
+
+`privatized` records whether the bundle carries a salted `libjulia`. A package
+without one warns if another wrapped package is already loaded. [`build_library`](@ref)
+sets this option; pass it directly only when using [`write_wrapper`](@ref) for
+a bundle built elsewhere.
 """
 struct PythonTarget <: AbstractTarget
     dir::String
@@ -29,21 +35,25 @@ struct PythonTarget <: AbstractTarget
     library_basename::String
     bundle_subdir::Union{Nothing, String}
     version::String
+    privatized::Bool
 end
 
 PythonTarget(dir::AbstractString, package_name::AbstractString,
              library_basename::AbstractString; bundle_subdir = nothing,
-             version::AbstractString = _DEFAULT_PACKAGE_VERSION) =
+             version::AbstractString = _DEFAULT_PACKAGE_VERSION,
+             privatized::Bool = false) =
     PythonTarget(String(dir), String(package_name), String(library_basename),
                  bundle_subdir === nothing ? nothing : String(bundle_subdir),
                  isempty(version) ? throw(ArgumentError(
-                     "PythonTarget version must not be empty")) : String(version))
+                     "PythonTarget version must not be empty")) : String(version),
+                 privatized)
 
 function Base.show(io::IO, t::PythonTarget)
     print(io, "PythonTarget(", repr(t.dir), ", ", repr(t.package_name),
               ", ", repr(t.library_basename))
     t.bundle_subdir === nothing || print(io, "; bundle_subdir = ", repr(t.bundle_subdir))
     t.version == _DEFAULT_PACKAGE_VERSION || print(io, "; version = ", repr(t.version))
+    t.privatized && print(io, "; privatized = true")
     print(io, ")")
 end
 
@@ -592,26 +602,34 @@ function _write_bindings(f::IO, dest::PythonTarget, abi_info::ABIInfo,
     println(f, "_lib = ctypes.CDLL(_resolve_library_path())")
     println(f)
 
-    # Warn when another wrapped library is already loaded.
+    # Record this package on a process-global sentinel so that a later
+    # non-privatized package can tell something is already loaded.
     println(f, "_JLW_LOADED_ATTR = \"_jlw_loaded_packages\"")
     println(f, "_jlw_loaded = getattr(sys, _JLW_LOADED_ATTR, None)")
     println(f, "if _jlw_loaded is None:")
     println(f, "    _jlw_loaded = set()")
     println(f, "    setattr(sys, _JLW_LOADED_ATTR, _jlw_loaded)")
     println(f, "_jlw_this_pkg = __package__ or __name__")
-    println(f, "if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:")
-    println(f, "    import warnings")
-    println(f, "    warnings.warn(")
-    println(f, "        f\"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a \"")
-    println(f, "        f\"process that already loaded {sorted(_jlw_loaded)!r}. Multiple \"")
-    println(f, "        \"JLW-wrapped libraries in one process is not a supported \"")
-    println(f, "        \"configuration: the dynamic linker silently shares a single \"")
-    println(f, "        \"libjulia across them, which assumes byte-compatible Julia \"")
-    println(f, "        \"versions and shares one Julia runtime. See the JuliaLibWrapping \"")
-    println(f, "        \"docs section on multiple wrapped libraries in one process.\",")
-    println(f, "        RuntimeWarning,")
-    println(f, "        stacklevel=2,")
-    println(f, "    )")
+    if !dest.privatized
+        # Without a private libjulia this package shares whatever runtime is
+        # already initialized, and the first call into whichever library did
+        # not initialize it aborts the process. A privatized package uses its
+        # own runtime and does not need to warn.
+        println(f, "if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:")
+        println(f, "    import warnings")
+        println(f, "    warnings.warn(")
+        println(f, "        f\"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a \"")
+        println(f, "        f\"process that already loaded {sorted(_jlw_loaded)!r}. \"")
+        println(f, "        \"This package was built without a private libjulia, so both \"")
+        println(f, "        \"packages resolve a single Julia runtime and the first call into \"")
+        println(f, "        \"whichever did not initialize it aborts the process. Rebuild with \"")
+        println(f, "        \"`privatize = true`, or compile both APIs into a single juliac \"")
+        println(f, "        \"library. See the JuliaLibWrapping docs section on multiple \"")
+        println(f, "        \"wrapped libraries in one process.\",")
+        println(f, "        RuntimeWarning,")
+        println(f, "        stacklevel=2,")
+        println(f, "    )")
+    end
     println(f, "_jlw_loaded.add(_jlw_this_pkg)")
     println(f)
 

--- a/JuliaLibWrapping/test/expected_carray3_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_carray3_lowlevel.py
@@ -42,12 +42,13 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     import warnings
     warnings.warn(
         f"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a "
-        f"process that already loaded {sorted(_jlw_loaded)!r}. Multiple "
-        "JLW-wrapped libraries in one process is not a supported "
-        "configuration: the dynamic linker silently shares a single "
-        "libjulia across them, which assumes byte-compatible Julia "
-        "versions and shares one Julia runtime. See the JuliaLibWrapping "
-        "docs section on multiple wrapped libraries in one process.",
+        f"process that already loaded {sorted(_jlw_loaded)!r}. "
+        "This package was built without a private libjulia, so both "
+        "packages resolve a single Julia runtime and the first call into "
+        "whichever did not initialize it aborts the process. Rebuild with "
+        "`privatize = true`, or compile both APIs into a single juliac "
+        "library. See the JuliaLibWrapping docs section on multiple "
+        "wrapped libraries in one process.",
         RuntimeWarning,
         stacklevel=2,
     )

--- a/JuliaLibWrapping/test/expected_cmatrix_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cmatrix_lowlevel.py
@@ -42,12 +42,13 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     import warnings
     warnings.warn(
         f"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a "
-        f"process that already loaded {sorted(_jlw_loaded)!r}. Multiple "
-        "JLW-wrapped libraries in one process is not a supported "
-        "configuration: the dynamic linker silently shares a single "
-        "libjulia across them, which assumes byte-compatible Julia "
-        "versions and shares one Julia runtime. See the JuliaLibWrapping "
-        "docs section on multiple wrapped libraries in one process.",
+        f"process that already loaded {sorted(_jlw_loaded)!r}. "
+        "This package was built without a private libjulia, so both "
+        "packages resolve a single Julia runtime and the first call into "
+        "whichever did not initialize it aborts the process. Rebuild with "
+        "`privatize = true`, or compile both APIs into a single juliac "
+        "library. See the JuliaLibWrapping docs section on multiple "
+        "wrapped libraries in one process.",
         RuntimeWarning,
         stacklevel=2,
     )

--- a/JuliaLibWrapping/test/expected_cstring_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cstring_lowlevel.py
@@ -41,12 +41,13 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     import warnings
     warnings.warn(
         f"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a "
-        f"process that already loaded {sorted(_jlw_loaded)!r}. Multiple "
-        "JLW-wrapped libraries in one process is not a supported "
-        "configuration: the dynamic linker silently shares a single "
-        "libjulia across them, which assumes byte-compatible Julia "
-        "versions and shares one Julia runtime. See the JuliaLibWrapping "
-        "docs section on multiple wrapped libraries in one process.",
+        f"process that already loaded {sorted(_jlw_loaded)!r}. "
+        "This package was built without a private libjulia, so both "
+        "packages resolve a single Julia runtime and the first call into "
+        "whichever did not initialize it aborts the process. Rebuild with "
+        "`privatize = true`, or compile both APIs into a single juliac "
+        "library. See the JuliaLibWrapping docs section on multiple "
+        "wrapped libraries in one process.",
         RuntimeWarning,
         stacklevel=2,
     )

--- a/JuliaLibWrapping/test/expected_libsimple_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_libsimple_lowlevel.py
@@ -42,12 +42,13 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     import warnings
     warnings.warn(
         f"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a "
-        f"process that already loaded {sorted(_jlw_loaded)!r}. Multiple "
-        "JLW-wrapped libraries in one process is not a supported "
-        "configuration: the dynamic linker silently shares a single "
-        "libjulia across them, which assumes byte-compatible Julia "
-        "versions and shares one Julia runtime. See the JuliaLibWrapping "
-        "docs section on multiple wrapped libraries in one process.",
+        f"process that already loaded {sorted(_jlw_loaded)!r}. "
+        "This package was built without a private libjulia, so both "
+        "packages resolve a single Julia runtime and the first call into "
+        "whichever did not initialize it aborts the process. Rebuild with "
+        "`privatize = true`, or compile both APIs into a single juliac "
+        "library. See the JuliaLibWrapping docs section on multiple "
+        "wrapped libraries in one process.",
         RuntimeWarning,
         stacklevel=2,
     )

--- a/JuliaLibWrapping/test/expected_rawptr_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_rawptr_lowlevel.py
@@ -41,12 +41,13 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     import warnings
     warnings.warn(
         f"Loading JuliaLibWrapping-generated package {_jlw_this_pkg!r} into a "
-        f"process that already loaded {sorted(_jlw_loaded)!r}. Multiple "
-        "JLW-wrapped libraries in one process is not a supported "
-        "configuration: the dynamic linker silently shares a single "
-        "libjulia across them, which assumes byte-compatible Julia "
-        "versions and shares one Julia runtime. See the JuliaLibWrapping "
-        "docs section on multiple wrapped libraries in one process.",
+        f"process that already loaded {sorted(_jlw_loaded)!r}. "
+        "This package was built without a private libjulia, so both "
+        "packages resolve a single Julia runtime and the first call into "
+        "whichever did not initialize it aborts the process. Rebuild with "
+        "`privatize = true`, or compile both APIs into a single juliac "
+        "library. See the JuliaLibWrapping docs section on multiple "
+        "wrapped libraries in one process.",
         RuntimeWarning,
         stacklevel=2,
     )

--- a/JuliaLibWrapping/test/runtests.jl
+++ b/JuliaLibWrapping/test/runtests.jl
@@ -334,6 +334,19 @@ end
             golden = read(joinpath(@__DIR__, "expected_libsimple_lowlevel.py"), String)
             @test bindings == golden
 
+            # Without a private libjulia, a second wrapped package in the
+            # process is a fatal configuration and the package says so.
+            @test occursin("aborts the process", bindings)
+            @test occursin("Rebuild with", bindings)
+            # A privatized package uses its own runtime, so it does not warn,
+            # but it still records itself for other packages to detect.
+            priv_dir = mktempdir()
+            write_wrapper(PythonTarget(priv_dir, "libsimple", "libsimple"; privatized = true),
+                          abi_info)
+            priv = read(joinpath(priv_dir, "libsimple", "_lowlevel.py"), String)
+            @test !occursin("RuntimeWarning", priv)
+            @test occursin("_jlw_loaded.add(_jlw_this_pkg)", priv)
+
             python3 = Sys.which("python3")
             if python3 === nothing
                 # CI must exercise the Python wrapper; locally we allow skipping

--- a/JuliaLibWrapping/test/test_build_library.jl
+++ b/JuliaLibWrapping/test/test_build_library.jl
@@ -193,8 +193,13 @@ using Test
                                    "abi_stress." * Base.Libc.Libdl.dlext)
             @test isfile(bundled_lib)
             # libjulia must be next to the user lib so the embedded
-            # RUNPATH ($ORIGIN/../lib[/julia]) resolves it.
-            @test any(startswith.(readdir(joinpath(pkgdir, "bundle", "lib")), "libjulia"))
+            # RUNPATH ($ORIGIN/../lib[/julia]) resolves it. Privatization is on
+            # by default for bundles, so every copy carries a salt prefix and
+            # none is named plain `libjulia*`.
+            libnames = readdir(joinpath(pkgdir, "bundle", "lib"))
+            salted = filter(f -> contains(f, "libjulia"), libnames)
+            @test !isempty(salted)
+            @test !any(startswith.(salted, "libjulia"))
 
             # The real test: can Python import the package and call a
             # function? `out` is added to PYTHONPATH so `abi_stress_py`


### PR DESCRIPTION
Bundled builds now give libjulia and libjulia-internal distinct SONAME prefixes. This allows separately wrapped libraries to initialize independent Julia runtimes in one process.

Set `privatize = false` to retain shared runtime linkage. Reject `privatize = true` without a bundle, where it cannot take effect.

Generated Python wrappers warn when a non-privatized package detects another wrapped package in the process.

Closes #28