### PR TITLE
Make CArray ownership a type parameter

### DIFF
--- a/JLWInterop/Project.toml
+++ b/JLWInterop/Project.toml
@@ -1,7 +1,7 @@
 name = "JLWInterop"
 uuid = "65e54657-ed21-41a3-96db-71ab7fa6d94b"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.2.0"
 
 [compat]
 OffsetArrays = "1.12"

--- a/JLWInterop/Project.toml
+++ b/JLWInterop/Project.toml
@@ -4,10 +4,12 @@ authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
 version = "0.1.0"
 
 [compat]
+OffsetArrays = "1.12"
 julia = "1.10"
 
 [extras]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["OffsetArrays", "Test"]

--- a/JLWInterop/src/JLWInterop.jl
+++ b/JLWInterop/src/JLWInterop.jl
@@ -20,25 +20,31 @@ for the terminating NUL.
 const JLW_MESSAGE_BYTES = 256
 
 """
-    CArray{T,N}
+    CArray{owned,T,N}
 
 Column-major N-D buffer for `@ccallable` boundaries. `data` points to
 `prod(dims)` contiguous elements of `T`.
 
 # Ownership contract
 
-`owned == 0` denotes borrowed storage; the caller must keep it alive and make
-it writable before mutation. `owned == 1` denotes storage allocated by
-`CArray(::AbstractArray)`; release it once with `Libc.free` or the `jlw_free`
-entrypoint emitted by [`@export_release_entrypoints`](@ref). Constructors that
-accept a pointer create borrowed arrays.
+`owned` is `:owned` or `:borrowed`, so whether a value must be released is a
+property of its type rather than of the value.
+
+`CArray{:owned,T,N}` holds Julia-allocated storage, produced by
+`CArray{:owned}(::AbstractArray)`. The consumer releases `data` exactly once,
+with `Libc.free` or the `jlw_free` entrypoint emitted by
+[`@export_release_entrypoints`](@ref).
+
+`CArray{:borrowed,T,N}` wraps memory the caller owns and keeps alive; the
+consumer never releases it, and must make the storage writable before
+mutating it. Pointer constructors build carriers of either ownership.
 
 # Example
 
 ```julia
 using JLWInterop
 
-Base.@ccallable function sum_values(a::CArray{Float64,2})::Float64
+Base.@ccallable function sum_values(a::CArray{:borrowed,Float64,2})::Float64
     return sum(a)
 end
 ```
@@ -50,67 +56,91 @@ interface with linear indexing, including bounds-checked access and mutation.
 The aliases [`CVector`](@ref) and [`CMatrix`](@ref) cover one and two
 dimensions.
 
-Binding targets can map this layout to native N-D array types without changing
-the ABI. They must preserve column-major dimension and stride semantics.
+Every construction path names an ownership: there is no defaulting
+constructor, and any parameter other than `:owned` or `:borrowed` is
+rejected.
+
+Binding targets can map this layout to native N-D array types without
+changing the ABI. They must preserve column-major dimension and stride
+semantics. The two ownerships are two distinct types, so a target reads
+"release this" or "do not release this" off the signature alone.
 """
-struct CArray{T, N} <: AbstractArray{T, N}
+struct CArray{owned, T, N} <: AbstractArray{T, N}
     dims::NTuple{N, Int32}
     data::Ptr{T}
-    owned::Int32   # 0 = caller-owned/borrowed; 1 = allocated by CArray(::AbstractArray)
+
+    function CArray{owned, T, N}(dims, data) where {owned, T, N}
+        owned === :owned || owned === :borrowed || throw(
+            ArgumentError(
+                "ownership parameter must be :owned or :borrowed, got $(repr(owned))"
+            )
+        )
+        return new{owned, T, N}(dims, data)
+    end
 end
 
 """
-    CVector{T}
+    CVector{owned,T}
 
-Alias for `CArray{T,1}`. See [`CArray`](@ref).
+Alias for `CArray{owned,T,1}`. See [`CArray`](@ref).
 """
-const CVector{T} = CArray{T, 1}
-
-"""
-    CMatrix{T}
-
-Alias for `CArray{T,2}`, laid out in column-major order. See [`CArray`](@ref).
-"""
-const CMatrix{T} = CArray{T, 2}
-
-# Infer `N` from the dimensions; borrowed (owned = 0).
-CArray{T}(dims::Tuple{Vararg{Integer, N}}, data::Ptr{T}) where {T, N} =
-    CArray{T, N}(dims, data)
-
-# Two-argument borrowed constructor.
-CArray{T, N}(dims::Tuple{Vararg{Integer, N}}, data::Ptr{T}) where {T, N} =
-    CArray{T, N}(dims, data, Int32(0))
-
-# Scalar constructors for the 1-D and 2-D aliases; borrowed (owned = 0).
-CArray{T, 1}(n::Integer, data::Ptr{T}) where {T} =
-    CArray{T, 1}((n,), data)
-CArray{T, 2}(rows::Integer, cols::Integer, data::Ptr{T}) where {T} =
-    CArray{T, 2}((rows, cols), data)
+const CVector{owned, T} = CArray{owned, T, 1}
 
 """
-    CArray(A::AbstractArray{T,N}) where {T,N}
+    CMatrix{owned,T}
 
-Allocate a dense column-major copy of `A`. The result has `owned == 1`; the
-consumer must release `data` once with `Libc.free` or the exported `jlw_free`.
+Alias for `CArray{owned,T,2}`, laid out in column-major order. See
+[`CArray`](@ref).
+"""
+const CMatrix{owned, T} = CArray{owned, T, 2}
+
+# Infer `T` and `N` from the pointer and the dimensions.
+CArray{owned}(dims::Tuple{Vararg{Integer, N}}, data::Ptr{T}) where {owned, T, N} =
+    CArray{owned, T, N}(dims, data)
+
+# Infer `N` from the dimensions.
+CArray{owned, T}(dims::Tuple{Vararg{Integer, N}}, data::Ptr{T}) where {owned, T, N} =
+    CArray{owned, T, N}(dims, data)
+
+# Scalar dimension forms for the 1-D and 2-D aliases.
+CArray{owned, T, 1}(n::Integer, data::Ptr{T}) where {owned, T} =
+    CArray{owned, T, 1}((n,), data)
+CArray{owned, T, 2}(rows::Integer, cols::Integer, data::Ptr{T}) where {owned, T} =
+    CArray{owned, T, 2}((rows, cols), data)
+
+"""
+    CArray{:owned}(A::AbstractArray{T,N}) where {T,N}
+
+Allocate a dense column-major copy of `A`, taking `A`'s values in iteration
+order and `A`'s `size` as `dims`. The consumer must release `data` once with
+`Libc.free` or the exported `jlw_free`.
+
+`CArray{:borrowed}(A)` throws an `ArgumentError`: a borrowed carrier wraps
+caller-managed memory and is built from a pointer.
 
 # Example
 
 ```julia
 using JLWInterop
 
-a = CArray([1.0 2.0; 3.0 4.0])
-a.owned == Int32(1)
+a = CArray{:owned}([1.0 2.0; 3.0 4.0])
 collect(a) == [1.0 2.0; 3.0 4.0]
 Libc.free(a.data)
 ```
 """
-function CArray(A::AbstractArray{T, N}) where {T, N}
+function CArray{owned}(A::AbstractArray{T, N}) where {owned, T, N}
+    owned === :owned || throw(
+        ArgumentError(
+            "only `CArray{:owned}` allocates a copy; `CArray{:borrowed}` wraps " *
+                "caller-managed memory and is constructed from a pointer"
+        )
+    )
     dense = Array{T, N}(undef, size(A))
     copyto!(dense, A)
     n = length(dense)
     data = Ptr{T}(Libc.malloc(max(n, 1) * sizeof(T)))
     GC.@preserve dense unsafe_copyto!(data, pointer(dense), n)
-    return CArray{T, N}(size(A), data, Int32(1))
+    return CArray{owned, T, N}(size(A), data)
 end
 
 Base.size(a::CArray) = Int.(a.dims)
@@ -121,7 +151,7 @@ Base.@propagate_inbounds function Base.getindex(a::CArray, i::Int)
     return unsafe_load(a.data, i)
 end
 
-Base.@propagate_inbounds function Base.setindex!(a::CArray{T}, x, i::Int) where {T}
+Base.@propagate_inbounds function Base.setindex!(a::CArray{owned, T}, x, i::Int) where {owned, T}
     @boundscheck checkbounds(a, i)
     unsafe_store!(a.data, convert(T, x), i)
     return a

--- a/JLWInterop/src/JLWInterop.jl
+++ b/JLWInterop/src/JLWInterop.jl
@@ -109,14 +109,26 @@ CArray{owned, T, 2}(rows::Integer, cols::Integer, data::Ptr{T}) where {owned, T}
     CArray{owned, T, 2}((rows, cols), data)
 
 """
-    CArray{:owned}(A::AbstractArray{T,N}) where {T,N}
+    CArray{:owned}(A::AbstractArray{T,N})
+    CArray{:borrowed}(A::DenseArray{T,N})
 
-Allocate a dense column-major copy of `A`, taking `A`'s values in iteration
-order and `A`'s `size` as `dims`. The consumer must release `data` once with
-`Libc.free` or the exported `jlw_free`.
+`CArray{:owned}(A)` allocates a dense column-major copy of `A`, taking `A`'s
+values in iteration order and `A`'s `size` as `dims`. The consumer must
+release `data` once with `Libc.free` or the exported `jlw_free`.
 
-`CArray{:borrowed}(A)` throws an `ArgumentError`: a borrowed carrier wraps
-caller-managed memory and is built from a pointer.
+`CArray{:borrowed}(A)` wraps `A`'s own storage without copying: `data` is
+`pointer(A)`. The caller must keep `A` alive (a rooted global, or
+`GC.@preserve` around every use) for as long as the carrier is in use. Only
+`DenseArray`s can be borrowed — their storage is already contiguous and
+column-major, so the alias is exact; borrowing any other array throws an
+`ArgumentError` rather than aliasing memory whose layout may not match.
+Non-`DenseArray` storage can still be copied with `CArray{:owned}(A)`, or
+wrapped through a pointer constructor by a caller who vouches for its
+layout.
+
+Neither constructor records axes: only `size(A)` crosses the boundary, so
+arrays with offset axes are handled correctly but index the same data from
+`1` on the other side.
 
 # Example
 
@@ -126,22 +138,38 @@ using JLWInterop
 a = CArray{:owned}([1.0 2.0; 3.0 4.0])
 collect(a) == [1.0 2.0; 3.0 4.0]
 Libc.free(a.data)
+
+buf = zeros(3)
+b = CArray{:borrowed}(buf)  # aliases buf; keep buf alive while b is in use
 ```
 """
 function CArray{owned}(A::AbstractArray{T, N}) where {owned, T, N}
-    owned === :owned || throw(
-        ArgumentError(
-            "only `CArray{:owned}` allocates a copy; `CArray{:borrowed}` wraps " *
-                "caller-managed memory and is constructed from a pointer"
+    if owned === :owned
+        dense = Array{T, N}(undef, size(A))
+        copyto!(dense, A)
+        n = length(dense)
+        data = Ptr{T}(Libc.malloc(max(n, 1) * sizeof(T)))
+        GC.@preserve dense unsafe_copyto!(data, pointer(dense), n)
+        return CArray{owned, T, N}(size(A), data)
+    elseif owned === :borrowed
+        throw(
+            ArgumentError(
+                "cannot borrow a " * string(typeof(A)) * ": only `DenseArray` " *
+                    "storage (contiguous, column-major) can be aliased; copy with " *
+                    "`CArray{:owned}(A)` or construct from a pointer"
+            )
         )
-    )
-    dense = Array{T, N}(undef, size(A))
-    copyto!(dense, A)
-    n = length(dense)
-    data = Ptr{T}(Libc.malloc(max(n, 1) * sizeof(T)))
-    GC.@preserve dense unsafe_copyto!(data, pointer(dense), n)
-    return CArray{owned, T, N}(size(A), data)
+    else
+        throw(
+            ArgumentError(
+                "ownership parameter must be :owned or :borrowed, got $(repr(owned))"
+            )
+        )
+    end
 end
+
+CArray{:borrowed}(A::DenseArray{T, N}) where {T, N} =
+    CArray{:borrowed, T, N}(size(A), pointer(A))
 
 Base.size(a::CArray) = Int.(a.dims)
 Base.IndexStyle(::Type{<:CArray}) = IndexLinear()

--- a/JLWInterop/test/runtests.jl
+++ b/JLWInterop/test/runtests.jl
@@ -325,13 +325,6 @@ using Test
         @test collect(v) == [10.0, 20.0, 30.0]
         Libc.free(v.data)
 
-        # Borrowed carriers wrap memory the caller already holds, so there is
-        # nothing for this constructor to do.
-        @test_throws(
-            "`CArray{:borrowed}` wraps caller-managed memory and is constructed from a pointer",
-            CArray{:borrowed}([1.0, 2.0])
-        )
-
         # `CArray <: AbstractArray`, so the same constructor promotes a
         # borrowed carrier into an owning copy.
         buf = Float64[5.0, 6.0]
@@ -344,6 +337,55 @@ using Test
             @test collect(copied) == [5.0, 6.0]
             Libc.free(copied.data)
         end
+
+        # The invalid-symbol rejection also covers the array-argument entry
+        # point.
+        @test_throws(
+            "ownership parameter must be :owned or :borrowed, got :mine",
+            CArray{:mine}([1.0, 2.0])
+        )
+    end
+
+    @testset "CArray{:borrowed} aliases dense arrays" begin
+        # `DenseArray` storage is already contiguous and column-major, so the
+        # constructor can alias it: `data` is `pointer(A)` and no copy is made.
+        # The caller keeps `A` alive while the carrier is in use.
+        buf = Float64[1.0, 2.0, 3.0]
+        GC.@preserve buf begin
+            v = CArray{:borrowed}(buf)
+            @test v isa CVector{:borrowed, Float64}
+            @test v.dims === (Int32(3),)
+            @test v.data === pointer(buf)
+            # Genuine aliasing, in both directions.
+            buf[2] = 20.0
+            @test v[2] === 20.0
+            v[3] = 30.0
+            @test buf[3] === 30.0
+        end
+
+        M = [1.0 2.0; 3.0 4.0]
+        GC.@preserve M begin
+            m = CArray{:borrowed}(M)
+            @test m isa CMatrix{:borrowed, Float64}
+            @test m.dims === (Int32(2), Int32(2))
+            @test collect(m) == M
+        end
+
+        # Non-`DenseArray` storage cannot be aliased safely, even when it
+        # happens to be contiguous: the layout guarantee lives in the type.
+        src = collect(1.0:6.0)
+        @test_throws(
+            "only `DenseArray` storage (contiguous, column-major) can be aliased",
+            CArray{:borrowed}(view(src, 2:2:6))
+        )
+        @test_throws(
+            "only `DenseArray` storage (contiguous, column-major) can be aliased",
+            CArray{:borrowed}(view(src, 1:6))
+        )
+        @test_throws(
+            "only `DenseArray` storage (contiguous, column-major) can be aliased",
+            CArray{:borrowed}(OffsetArray([1.0, 2.0], -1))
+        )
     end
 
     @testset "CArray{:owned} from arrays with unconventional axes" begin

--- a/JLWInterop/test/runtests.jl
+++ b/JLWInterop/test/runtests.jl
@@ -1,4 +1,5 @@
 using JLWInterop
+using OffsetArrays
 using Test
 
 @testset "JLWInterop" begin
@@ -46,17 +47,17 @@ using Test
 
     @testset "CArray aliases" begin
         # CVector and CMatrix are CArray aliases.
-        @test CVector{Float64} === CArray{Float64, 1}
-        @test CMatrix{Float64} === CArray{Float64, 2}
-        @test CVector === CArray{T, 1} where {T}
-        @test CMatrix === CArray{T, 2} where {T}
+        @test CVector{:owned, Float64} === CArray{:owned, Float64, 1}
+        @test CMatrix{:borrowed, Float64} === CArray{:borrowed, Float64, 2}
+        @test CVector === CArray{owned, T, 1} where {owned, T}
+        @test CMatrix === CArray{owned, T, 2} where {owned, T}
     end
 
     @testset "CVector AbstractVector interface" begin
         # Keep the borrowed buffer alive while using the view.
         buf = Float64[10.0, 20.0, 30.0, 40.0]
         GC.@preserve buf begin
-            v = CVector{Float64}(Int32(length(buf)), pointer(buf))
+            v = CVector{:borrowed, Float64}(Int32(length(buf)), pointer(buf))
 
             @test v isa AbstractVector{Float64}
             @test IndexStyle(typeof(v)) === IndexLinear()
@@ -154,7 +155,7 @@ using Test
         # Column-major storage; verify both linear and Cartesian indexing.
         buf = Float64[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]  # 2x3, col-major
         GC.@preserve buf begin
-            m = CMatrix{Float64}(Int32(2), Int32(3), pointer(buf))
+            m = CMatrix{:borrowed, Float64}(Int32(2), Int32(3), pointer(buf))
 
             @test m isa AbstractMatrix{Float64}
             @test IndexStyle(typeof(m)) === IndexLinear()
@@ -192,7 +193,7 @@ using Test
         # 2 × 3 × 4 = 24 elements in column-major layout.
         buf = collect(1.0:24.0)
         GC.@preserve buf begin
-            a = CArray{Float64, 3}((2, 3, 4), pointer(buf))
+            a = CArray{:borrowed, Float64, 3}((2, 3, 4), pointer(buf))
 
             @test a isa AbstractArray{Float64, 3}
             @test IndexStyle(typeof(a)) === IndexLinear()
@@ -228,82 +229,146 @@ using Test
 
     @testset "CArray layout" begin
         # C and Python emitters rely on this field layout.
-        @test fieldnames(CArray) == (:dims, :data, :owned)
+        @test fieldnames(CArray) == (:dims, :data)
 
-        @test fieldtype(CVector{Float64}, :dims) === NTuple{1, Int32}
-        @test fieldtype(CVector{Float64}, :data) === Ptr{Float64}
-        @test fieldtype(CVector{Float64}, :owned) === Int32
-        @test isbitstype(CVector{Float64})
-        @test iszero(fieldoffset(CVector{Float64}, 1))
+        @test fieldtype(CVector{:borrowed, Float64}, :dims) === NTuple{1, Int32}
+        @test fieldtype(CVector{:borrowed, Float64}, :data) === Ptr{Float64}
+        @test isbitstype(CVector{:borrowed, Float64})
+        @test iszero(fieldoffset(CVector{:borrowed, Float64}, 1))
         # One Int32 (4 bytes) pads out to pointer alignment (8 bytes).
-        @test fieldoffset(CVector{Float64}, 2) == 8
-        @test fieldoffset(CVector{Float64}, 3) == 16
-        @test sizeof(CVector{Float64}) == 24
+        @test fieldoffset(CVector{:borrowed, Float64}, 2) == 8
+        @test sizeof(CVector{:borrowed, Float64}) == 16
 
-        @test fieldtype(CMatrix{Float64}, :dims) === NTuple{2, Int32}
-        @test fieldtype(CMatrix{Float64}, :data) === Ptr{Float64}
-        @test fieldtype(CMatrix{Float64}, :owned) === Int32
-        @test isbitstype(CMatrix{Float64})
-        @test iszero(fieldoffset(CMatrix{Float64}, 1))
+        @test fieldtype(CMatrix{:owned, Float64}, :dims) === NTuple{2, Int32}
+        @test fieldtype(CMatrix{:owned, Float64}, :data) === Ptr{Float64}
+        @test isbitstype(CMatrix{:owned, Float64})
+        @test iszero(fieldoffset(CMatrix{:owned, Float64}, 1))
         # Two Int32s pack tightly into 8 bytes, then data is pointer-aligned.
-        @test fieldoffset(CMatrix{Float64}, 2) == 8
-        @test fieldoffset(CMatrix{Float64}, 3) == 16
-        @test sizeof(CMatrix{Float64}) == 24
+        @test fieldoffset(CMatrix{:owned, Float64}, 2) == 8
+        @test sizeof(CMatrix{:owned, Float64}) == 16
 
-        @test fieldtype(CArray{Float64, 3}, :dims) === NTuple{3, Int32}
-        @test fieldtype(CArray{Float64, 3}, :owned) === Int32
-        @test isbitstype(CArray{Float64, 3})
-        @test iszero(fieldoffset(CArray{Float64, 3}, 1))
+        @test fieldtype(CArray{:borrowed, Float64, 3}, :dims) === NTuple{3, Int32}
+        @test isbitstype(CArray{:borrowed, Float64, 3})
+        @test iszero(fieldoffset(CArray{:borrowed, Float64, 3}, 1))
         # Three Int32s = 12 bytes, padded to 16 for pointer alignment.
-        @test fieldoffset(CArray{Float64, 3}, 2) == 16
-        @test fieldoffset(CArray{Float64, 3}, 3) == 24
-        @test sizeof(CArray{Float64, 3}) == 32
+        @test fieldoffset(CArray{:borrowed, Float64, 3}, 2) == 16
+        @test sizeof(CArray{:borrowed, Float64, 3}) == 24
+
+        # Ownership is part of the type, so the two flavors are distinct types
+        # with identical layout.
+        @test CVector{:owned, Float64} !== CVector{:borrowed, Float64}
+        @test sizeof(CVector{:owned, Float64}) == sizeof(CVector{:borrowed, Float64})
+    end
+
+    @testset "CArray ABI names" begin
+        # `juliac` writes the ABI JSON's struct names with
+        # `repr(dt; context = :compact => true)`, and JuliaLibWrapping's
+        # recognizer parses the ownership back out of that text. Aliases print
+        # in preference to the raw spelling.
+        compact(T) = repr(T; context = :compact => true)
+        @test compact(CVector{:owned, Float64}) == "CVector{:owned, Float64}"
+        @test compact(CMatrix{:borrowed, Float32}) == "CMatrix{:borrowed, Float32}"
+        @test compact(CArray{:owned, Float64, 3}) == "CArray{:owned, Float64, 3}"
     end
 
     @testset "CArray constructors" begin
-        # Tuple dimensions convert to Int32; pointer constructors borrow.
-        a = CArray{Float64}((Int32(2), Int32(3)), Ptr{Float64}(0))
-        @test a isa CMatrix{Float64}
+        # Tuple dimensions convert to Int32; the ownership parameter is
+        # required at every entry point.
+        a = CArray{:borrowed, Float64}((Int32(2), Int32(3)), Ptr{Float64}(0))
+        @test a isa CMatrix{:borrowed, Float64}
         @test a.dims === (Int32(2), Int32(3))
-        @test a.owned === Int32(0)
 
-        a2 = CArray{Float64, 2}((2, 3), Ptr{Float64}(0))
+        # `T` and `N` are both inferred from the pointer and dimensions.
+        a2 = CArray{:borrowed}((2, 3), Ptr{Float64}(0))
+        @test a2 isa CMatrix{:borrowed, Float64}
         @test a2.dims === (Int32(2), Int32(3))
-        @test a2.owned === Int32(0)
+
+        a3 = CArray{:owned, Float64, 2}((2, 3), Ptr{Float64}(0))
+        @test a3 isa CMatrix{:owned, Float64}
+        @test a3.dims === (Int32(2), Int32(3))
 
         # Scalar-form shortcuts for 1-D and 2-D.
-        v = CVector{Float64}(Int32(4), Ptr{Float64}(0))
+        v = CVector{:borrowed, Float64}(Int32(4), Ptr{Float64}(0))
         @test v.dims === (Int32(4),)
         @test v.data === Ptr{Float64}(0)
-        @test v.owned === Int32(0)
 
-        m = CMatrix{Float64}(2, 3, Ptr{Float64}(0))
+        m = CMatrix{:owned, Float64}(2, 3, Ptr{Float64}(0))
         @test m.dims === (Int32(2), Int32(3))
-        @test m.owned === Int32(0)
+
+        # There is no ownership-defaulting constructor.
+        @test_throws MethodError CArray([1.0])
+        @test_throws MethodError CVector{Float64}(1, Ptr{Float64}(0))
+
+        # Only :owned and :borrowed name an ownership.
+        @test_throws(
+            "ownership parameter must be :owned or :borrowed, got :mine",
+            CArray{:mine, Float64, 1}((Int32(1),), Ptr{Float64}(0))
+        )
+        @test_throws(
+            "ownership parameter must be :owned or :borrowed, got 1",
+            CArray{1, Float64, 1}((Int32(1),), Ptr{Float64}(0))
+        )
     end
 
-    @testset "CArray owned flag" begin
-        # The array constructor allocates an owning column-major copy.
+    @testset "CArray{:owned} allocates" begin
+        # The array constructor allocates a column-major copy the consumer owns.
         src = [1.0 2.0; 3.0 4.0]  # 2x2, column-major
-        a = CArray(src)
-        @test fieldtype(CArray, :owned) === Int32
-        @test a.owned === Int32(1)
+        a = CArray{:owned}(src)
+        @test a isa CMatrix{:owned, Float64}
         @test a.dims === (Int32(2), Int32(2))
         @test collect(a) == src
         Libc.free(a.data)
 
-        # 1-D owning constructor.
-        v = CArray([10.0, 20.0, 30.0])
-        @test v.owned === Int32(1)
+        # 1-D.
+        v = CArray{:owned}([10.0, 20.0, 30.0])
+        @test v isa CVector{:owned, Float64}
         @test collect(v) == [10.0, 20.0, 30.0]
         Libc.free(v.data)
 
-        # Access does not depend on ownership.
+        # Borrowed carriers wrap memory the caller already holds, so there is
+        # nothing for this constructor to do.
+        @test_throws(
+            "`CArray{:borrowed}` wraps caller-managed memory and is constructed from a pointer",
+            CArray{:borrowed}([1.0, 2.0])
+        )
+
+        # `CArray <: AbstractArray`, so the same constructor promotes a
+        # borrowed carrier into an owning copy.
         buf = Float64[5.0, 6.0]
         GC.@preserve buf begin
-            borrowed = CArray{Float64, 1}((Int32(2),), pointer(buf), Int32(0))
+            borrowed = CVector{:borrowed, Float64}(Int32(2), pointer(buf))
             @test collect(borrowed) == [5.0, 6.0]
+            copied = CArray{:owned}(borrowed)
+            @test copied isa CVector{:owned, Float64}
+            @test copied.data !== borrowed.data
+            @test collect(copied) == [5.0, 6.0]
+            Libc.free(copied.data)
         end
+    end
+
+    @testset "CArray{:owned} from arrays with unconventional axes" begin
+        # `size(A)` supplies `dims` and the values arrive in iteration order,
+        # so arrays whose axes do not start at 1 copy correctly.
+        o = OffsetArray([10.0, 20.0, 30.0], -1:1)
+        v = CArray{:owned}(o)
+        @test v.dims === (Int32(3),)
+        @test size(v) == size(o)
+        @test collect(v) == collect(o)
+        Libc.free(v.data)
+
+        o2 = OffsetArray([1.0 2.0; 3.0 4.0], 0:1, 5:6)
+        m = CArray{:owned}(o2)
+        @test m.dims === (Int32(2), Int32(2))
+        @test size(m) == size(o2)
+        @test collect(m) == collect(o2)
+        Libc.free(m.data)
+
+        # A non-contiguous view is densified by the copy.
+        src = collect(1.0:6.0)
+        w = CArray{:owned}(view(src, 2:2:6))
+        @test w.dims === (Int32(3),)
+        @test collect(w) == [2.0, 4.0, 6.0]
+        Libc.free(w.data)
     end
 
     @testset "CStrArray round-trip" begin

--- a/JuliaLibWrapping/Project.toml
+++ b/JuliaLibWrapping/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaLibWrapping"
 uuid = "d61f35a8-f6af-436f-bc10-cee6b101f7bd"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
 
 [deps]

--- a/JuliaLibWrapping/docs/Project.toml
+++ b/JuliaLibWrapping/docs/Project.toml
@@ -11,5 +11,5 @@ path = ".."
 
 [compat]
 Documenter = "1"
-JLWInterop = "0.1"
-JuliaLibWrapping = "0.1"
+JLWInterop = "0.2"
+JuliaLibWrapping = "0.2"

--- a/JuliaLibWrapping/docs/src/concepts.md
+++ b/JuliaLibWrapping/docs/src/concepts.md
@@ -113,7 +113,7 @@ package directory:
 - `_facade.py` — the package's public API. JuliaLibWrapping creates this
   file only if it does not exist. Its initial version wraps entrypoints whose
   arguments and return are recognized —
-  primitive scalars, `CVector{T}`, `CMatrix{T}`, `CString`, or a
+  primitive scalars, `CVector{owned,T}`, `CMatrix{owned,T}`, `CString`, or a
   direct `JLWStatus` return — is auto-wrapped to accept and return
   idiomatic Python objects (numpy arrays, `str`). Entrypoints with a
   raw pointer, an unrecognized struct, or an embedded `JLWStatus`

--- a/JuliaLibWrapping/docs/src/jlwinterop.md
+++ b/JuliaLibWrapping/docs/src/jlwinterop.md
@@ -67,7 +67,11 @@ flavors are two distinct types with identical layout.
 
 - `CArray{:borrowed,T,N}` wraps memory the caller owns. The caller keeps it
   alive and makes it writable before mutation; the consumer never releases it.
-  Pointer constructors build carriers of either ownership.
+  `CArray{:borrowed}(A::DenseArray)` aliases `A`'s own storage (`pointer(A)`)
+  without copying; other array types are refused, since only `DenseArray`
+  guarantees the contiguous column-major layout the carrier promises. Pointer
+  constructors build carriers of either ownership for callers who vouch for
+  the layout themselves.
 - `CArray{:owned,T,N}` holds a Julia allocation. `CArray{:owned}(A)`
   `Libc.malloc`s a dense column-major copy of `A`; the consumer releases
   `data` exactly once.

--- a/JuliaLibWrapping/docs/src/jlwinterop.md
+++ b/JuliaLibWrapping/docs/src/jlwinterop.md
@@ -12,10 +12,10 @@ JLWInterop
 
 The package defines fixed-layout types for passing values across a C ABI.
 Borrowed values do not own their underlying storage; the caller must keep the
-storage alive for the duration of the call. Types that support owning returns
-record ownership in an `owned` field. The types are `isbits` when their element
-types are, work with `juliac --trim`, and cross a `@ccallable` boundary without
-allocating a Julia object.
+storage alive for the duration of the call. `CArray` states its ownership in
+its type; `CStrArray` and `CDict` record it in an `owned` field. The types are
+`isbits` when their element types are, work with `juliac --trim`, and cross a
+`@ccallable` boundary without allocating a Julia object.
 
 JuliaLibWrapping targets recognize these types structurally, by name and field
 layout. Using `JLWInterop` keeps those layouts consistent across libraries.
@@ -55,47 +55,59 @@ jlw_error
 JLW_MESSAGE_BYTES
 ```
 
-## `CArray{T,N}` — N-D numeric buffer (column-major)
+## `CArray{owned,T,N}` — N-D numeric buffer (column-major)
 
-`CArray{T,N}` is `(dims::NTuple{N,Int32}, data::Ptr{T}, owned::Int32)` in
-column-major order. Targets may map this layout to native array types.
+`CArray{owned,T,N}` is `(dims::NTuple{N,Int32}, data::Ptr{T})` in column-major
+order. Targets may map this layout to native array types.
 
 ### `CArray` ownership contract
 
-As with `CStrArray` and `CDict`, `owned == 0` denotes borrowed storage and
-`owned == 1` denotes Julia-allocated storage.
+Ownership is the leading type parameter, `:owned` or `:borrowed`, so the two
+flavors are two distinct types with identical layout.
 
-- Pointer constructors borrow. The caller must keep the buffer alive and make
-  it writable before mutation.
-- `CArray(A::AbstractArray)` **transfers ownership**: it `Libc.malloc`s a dense
-  column-major copy of `A` and sets `owned = 1`. A target must copy or transfer
-  ownership before releasing this storage.
+- `CArray{:borrowed,T,N}` wraps memory the caller owns. The caller keeps it
+  alive and makes it writable before mutation; the consumer never releases it.
+  Pointer constructors build carriers of either ownership.
+- `CArray{:owned,T,N}` holds a Julia allocation. `CArray{:owned}(A)`
+  `Libc.malloc`s a dense column-major copy of `A`; the consumer releases
+  `data` exactly once.
 
-### Python target
-
-The generated `as_numpy()` returns a zero-copy view. For an owning return, the
-façade copies the view before releasing the Julia allocation. Low-level callers
-can use the idempotent `.free()` method.
-
-Unlike `CStrArray`/`CDict`, whose façade falls back to a direct
-re-export at build time when release entrypoints are missing, a library
-that returns an owned `CArray` without exporting them still gets a full
-auto-wrapped return — the failure surfaces only at runtime, as `.free()`
-raising `RuntimeError`, because gating `CArray` returns at build time
-would demote every existing borrowed-`CArray` library.
+There is no ownership-defaulting constructor, and any parameter other than
+`:owned` or `:borrowed` is rejected, so an ownership is never guessed.
 
 The one- and two-dimensional aliases are:
 
 ```julia
-const CVector{T} = CArray{T,1}
-const CMatrix{T} = CArray{T,2}
+const CVector{owned,T} = CArray{owned,T,1}
+const CMatrix{owned,T} = CArray{owned,T,2}
 ```
 
-For `N ≥ 2`, the generated Python `from_numpy` helper requires a
-Fortran-contiguous array. Convert row-major input with `np.asfortranarray`.
+`CArray{owned,T,N} <: AbstractArray{T,N}` with linear indexing. It supports
+standard array operations; mutate only writable storage.
 
-`CArray{T,N} <: AbstractArray{T,N}` with linear indexing. It supports standard
-array operations; mutate only writable storage.
+### Python target
+
+A borrowed return becomes a zero-copy numpy view: the façade calls
+`as_numpy()` and hands the view back, because the storage stays the caller's.
+An owning return is copied into a fresh numpy array and the Julia allocation
+is released in a `finally`. The generated classes follow: a borrowed class
+gets `from_numpy` and `as_numpy` and no `free()`; an owning class gets
+`as_numpy` and an idempotent `free()`, and no `from_numpy`.
+
+A library returning an owning `CArray` without
+[`@export_release_entrypoints`](@ref) is demoted at build time to a `TODO`
+re-export naming the macro to add — the same rule as `CStrArray` and `CDict`.
+An owning `CArray` *argument* is likewise left to a human: it would transfer a
+Julia allocation into the library, which numpy cannot supply.
+
+For `N ≥ 2`, the generated `from_numpy` helper requires a Fortran-contiguous
+array. Convert row-major input with `np.asfortranarray`.
+
+### C target
+
+The two ownerships mangle to two distinct typedefs
+(`CVector_owned_Float64`, `CVector_borrowed_Float64`), so whether to free a
+returned buffer is visible in the signature.
 
 ```@docs
 CArray

--- a/JuliaLibWrapping/docs/src/tutorial.md
+++ b/JuliaLibWrapping/docs/src/tutorial.md
@@ -13,15 +13,16 @@ types:
 
 | JLWInterop type            | Where it appears in `ols`            |
 |----------------------------|--------------------------------------|
-| `CMatrix{Float64}`         | design matrix `X`                    |
-| `CVector{Float64}`         | response `y`, coefficients, predictions |
+| `CMatrix{:borrowed,Float64}` | design matrix `X`                  |
+| `CVector{:borrowed,Float64}` | response `y`, coefficients, predictions |
 | `Float64` (primitive)      | `r_squared`                          |
 | `CString`                  | output buffer for `summary_report`   |
 | `JLWStatus` (direct)       | return of `predict`                  |
 | `JLWStatus` (embedded)     | `FitResult.status` field             |
 
-`CMatrix` and `CVector` are aliases for `CArray` specializations. The example
-uses `X \ y` from `LinearAlgebra`.
+`CMatrix` and `CVector` are aliases for `CArray` specializations, and their
+leading `:borrowed` parameter says the library never owns these buffers. The
+example uses `X \ y` from `LinearAlgebra`.
 
 ## 1. The Julia source
 
@@ -36,21 +37,21 @@ using LinearAlgebra
 
 struct FitResult
     status::JLWStatus
-    coeffs::CVector{Float64}
+    coeffs::CVector{:borrowed, Float64}
     r_squared::Float64
 end
 
-Base.@ccallable function fit(X::CMatrix{Float64},
-                              y::CVector{Float64},
-                              coeffs_buf::CVector{Float64})::FitResult
+Base.@ccallable function fit(X::CMatrix{:borrowed, Float64},
+                              y::CVector{:borrowed, Float64},
+                              coeffs_buf::CVector{:borrowed, Float64})::FitResult
     # … shape checks, then `coeffs = X \\ y`; copy into `coeffs_buf`,
     # compute R^2, and return FitResult with JLWStatus(0,…) on success
     # or JLWStatus(code, msg) on a recognized failure.
 end
 
-Base.@ccallable function predict(coeffs::CVector{Float64},
-                                  X::CMatrix{Float64},
-                                  out::CVector{Float64})::JLWStatus
+Base.@ccallable function predict(coeffs::CVector{:borrowed, Float64},
+                                  X::CMatrix{:borrowed, Float64},
+                                  out::CVector{:borrowed, Float64})::JLWStatus
 
 Base.@ccallable function summary_report(result::FitResult,
                                          buf::CString)::JLWStatus
@@ -58,9 +59,9 @@ Base.@ccallable function summary_report(result::FitResult,
 
 See `examples/ols/src/ols.jl` for the complete implementation.
 
-`coeffs_buf` and `out` are *caller-allocated* buffers: the library
-writes into them but does not own them. This is generally true for
-JLWInterop types that hold pointers, `CArray` and `CString`.
+`coeffs_buf` and `out` are *caller-allocated* buffers: the library writes into
+them but does not own them, which is what the `:borrowed` parameter records.
+`CString` borrows likewise.
 
 Errors travel back as a `JLWStatus`,
 either returned directly (`predict`, `summary_report`) or embedded in
@@ -228,7 +229,7 @@ except JLWError as e:
 The expected `out` is `array([2.04, 4.02, 6., 7.98, 9.96])`, followed by the
 error message.
 
-`np.asfortranarray` is required for any `CMatrix{T}` argument: JLWInterop's
+`np.asfortranarray` is required for any `CMatrix{owned,T}` argument: JLWInterop's
 `CArray` is column-major, and the automatically created façade rejects a
 row-major view rather than silently transposing. You can edit the wrapper to
 accept a different interface.
@@ -249,9 +250,9 @@ def fit(X, y):
     y = np.ascontiguousarray(y, dtype=np.float64)
     coeffs = np.zeros(X.shape[1])
     result = _lowlevel.fit(
-        _lowlevel.CMatrix_Float64.from_numpy(X),
-        _lowlevel.CVector_Float64.from_numpy(y),
-        _lowlevel.CVector_Float64.from_numpy(coeffs),
+        _lowlevel.CMatrix_borrowed_Float64.from_numpy(X),
+        _lowlevel.CVector_borrowed_Float64.from_numpy(y),
+        _lowlevel.CVector_borrowed_Float64.from_numpy(coeffs),
     )
     return coeffs, result
 ```

--- a/JuliaLibWrapping/examples/abi_stress/src/abi_stress.jl
+++ b/JuliaLibWrapping/examples/abi_stress/src/abi_stress.jl
@@ -6,20 +6,21 @@ module abi_stress
 # arguments — so the wrapper emitters have something to chew on. This is a
 # stress fixture, not a tutorial example.
 
-struct CArray{T, N}
+# Kept in sync with JLWInterop.CArray so the recognizer still matches:
+# ownership is a leading Symbol type parameter and the layout is two fields.
+struct CArray{owned, T, N}
     dims::NTuple{N, Int32}
     data::Ptr{T}
-    owned::Int32   # kept in sync with JLWInterop.CArray so the recognizer still matches
 end
-const CVector{T} = CArray{T, 1}
+const CVector{owned, T} = CArray{owned, T, 1}
 
 struct CVectorPair{T}
-    from::CVector{T}
-    to::CVector{T}
+    from::CVector{:borrowed, T}
+    to::CVector{:borrowed, T}
 end
 
 struct CTree{T}
-    children::CVector{CTree{T}}
+    children::CVector{:borrowed, CTree{T}}
 end
 
 struct MyTwoVec
@@ -58,7 +59,7 @@ end
 # Exercises the N=3 case: the JuliaLibWrapping wrapper emitters generate the
 # rank-agnostic CArray helpers, and juliac's "array" ABI kind carries the
 # `NTuple{3,Int32}` shape.
-Base.@ccallable function sum3d(a::CArray{Float64, 3})::Float64
+Base.@ccallable function sum3d(a::CArray{:borrowed, Float64, 3})::Float64
     s = 0.0
     n = Int(a.dims[1]) * Int(a.dims[2]) * Int(a.dims[3])
     for i in 1:n

--- a/JuliaLibWrapping/examples/boundary/Project.toml
+++ b/JuliaLibWrapping/examples/boundary/Project.toml
@@ -12,5 +12,5 @@ JLWInterop = "65e54657-ed21-41a3-96db-71ab7fa6d94b"
 # entry project will add their own `[sources]` here.
 
 [compat]
-JLWInterop = "0.1"
+JLWInterop = "0.2"
 julia = "1.13"

--- a/JuliaLibWrapping/examples/boundary/build-env/Project.toml
+++ b/JuliaLibWrapping/examples/boundary/build-env/Project.toml
@@ -22,5 +22,5 @@ JuliaLibWrapping = {path = "../../.."}
 
 [compat]
 JuliaC = "0.3"
-JuliaLibWrapping = "0.1"
+JuliaLibWrapping = "0.2"
 julia = "1.13"

--- a/JuliaLibWrapping/examples/boundary/src/boundary.jl
+++ b/JuliaLibWrapping/examples/boundary/src/boundary.jl
@@ -38,11 +38,11 @@ Base.@ccallable function echo_dict(d::CDict{Float64})::CDict{Float64}
     return d
 end
 
-# Owning CArray return: `make_vec` mallocs a fresh vector and returns it with
-# `owned == 1`; the façade copies it into a numpy array and frees the
-# Julia-allocated buffer via `jlw_free`.
-Base.@ccallable function make_vec(n::Int64)::CVector{Float64}
-    return CArray(collect(Float64, 1:n))
+# Owning CArray return: `make_vec` mallocs a fresh vector and hands it over;
+# the façade copies it into a numpy array and frees the Julia-allocated
+# buffer via `jlw_free`.
+Base.@ccallable function make_vec(n::Int64)::CVector{:owned, Float64}
+    return CArray{:owned}(collect(Float64, 1:n))
 end
 
 end # module

--- a/JuliaLibWrapping/examples/boundary/test/smoke.py
+++ b/JuliaLibWrapping/examples/boundary/test/smoke.py
@@ -19,10 +19,10 @@ assert b.maybe_sqrt(-1.0) is None
 assert b.echo_strs(["x", "y"]) == ["x", "y"]
 assert b.echo_dict({"k": 1.0}) == {"k": 1.0}
 
-# Owning CArray return: make_vec mallocs a fresh vector (owned == 1); the
-# façade copies it into a numpy array and frees the Julia-allocated buffer
-# before returning — the same copy-then-free contract as echo_strs/echo_dict's
-# owning-return sibling functions, extended to CArray.
+# Owning CArray return: make_vec mallocs a fresh vector, and its
+# `CVector{:owned, Float64}` return type tells the generator so; the façade
+# copies it into a numpy array and frees the Julia-allocated buffer before
+# returning — the same copy-then-free contract as upcase_strs/make_dict.
 assert np.array_equal(b.make_vec(4), np.array([1.0, 2.0, 3.0, 4.0]))
 
 # no-double-free / leak hammer: repeated owning returns AND pass-through

--- a/JuliaLibWrapping/examples/ols/Project.toml
+++ b/JuliaLibWrapping/examples/ols/Project.toml
@@ -13,5 +13,5 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 # entry project will add their own `[sources]` here.
 
 [compat]
-JLWInterop = "0.1"
+JLWInterop = "0.2"
 julia = "1.13"

--- a/JuliaLibWrapping/examples/ols/build-env/Project.toml
+++ b/JuliaLibWrapping/examples/ols/build-env/Project.toml
@@ -22,5 +22,5 @@ JuliaLibWrapping = {path = "../../.."}
 
 [compat]
 JuliaC = "0.3"
-JuliaLibWrapping = "0.1"
+JuliaLibWrapping = "0.2"
 julia = "1.13"

--- a/JuliaLibWrapping/examples/ols/src/ols.jl
+++ b/JuliaLibWrapping/examples/ols/src/ols.jl
@@ -12,15 +12,15 @@ using LinearAlgebra
 
 struct FitResult
     status::JLWStatus
-    coeffs::CVector{Float64}
+    coeffs::CVector{:borrowed, Float64}
     r_squared::Float64
 end
 
 # Caller-owned storage discipline: `coeffs_buf` is allocated by the caller
 # and outlives the call; the returned `FitResult.coeffs` aliases it.
-Base.@ccallable function fit(X::CMatrix{Float64},
-                              y::CVector{Float64},
-                              coeffs_buf::CVector{Float64})::FitResult
+Base.@ccallable function fit(X::CMatrix{:borrowed, Float64},
+                              y::CVector{:borrowed, Float64},
+                              coeffs_buf::CVector{:borrowed, Float64})::FitResult
     n, p = size(X)
     if length(y) != n
         return FitResult(jlw_error(1, "y length must match X rows"), coeffs_buf, 0.0)
@@ -58,9 +58,9 @@ Base.@ccallable function fit(X::CMatrix{Float64},
     return FitResult(jlw_ok(), coeffs_buf, r_squared)
 end
 
-Base.@ccallable function predict(coeffs::CVector{Float64},
-                                  X::CMatrix{Float64},
-                                  out::CVector{Float64})::JLWStatus
+Base.@ccallable function predict(coeffs::CVector{:borrowed, Float64},
+                                  X::CMatrix{:borrowed, Float64},
+                                  out::CVector{:borrowed, Float64})::JLWStatus
     n, p = size(X)
     if length(coeffs) != p
         return jlw_error(1, "coeffs length must match X cols")

--- a/JuliaLibWrapping/examples/ols/test/smoke.py
+++ b/JuliaLibWrapping/examples/ols/test/smoke.py
@@ -17,17 +17,18 @@ def _fit(X, y):
 
     `fit`'s return type (`FitResult`) embeds a `JLWStatus`, so
     JuliaLibWrapping's façade auto-wrapper leaves it as a mechanical
-    re-export: callers pass `CMatrix_Float64`/`CVector_Float64` wrappers
-    directly rather than bare numpy arrays.
+    re-export: callers pass `CMatrix_borrowed_Float64`/
+    `CVector_borrowed_Float64` wrappers directly rather than bare numpy
+    arrays.
     """
     n, p = X.shape
     Xf = np.asfortranarray(X, dtype=np.float64)
     yf = np.asfortranarray(y, dtype=np.float64)
     coeffs_buf = np.zeros(p, dtype=np.float64)
 
-    X_c = ols_py.CMatrix_Float64.from_numpy(Xf)
-    y_c = ols_py.CVector_Float64.from_numpy(yf)
-    coeffs_c = ols_py.CVector_Float64.from_numpy(coeffs_buf)
+    X_c = ols_py.CMatrix_borrowed_Float64.from_numpy(Xf)
+    y_c = ols_py.CVector_borrowed_Float64.from_numpy(yf)
+    coeffs_c = ols_py.CVector_borrowed_Float64.from_numpy(coeffs_buf)
 
     result = ols_py.fit(X_c, y_c, coeffs_c)
     assert result.status.code == 0, (

--- a/JuliaLibWrapping/src/python.jl
+++ b/JuliaLibWrapping/src/python.jl
@@ -226,16 +226,17 @@ const scalar_payload_types = Dict{String, String}(
 
 [`carray_struct_info`](@ref) with this emitter's type tables applied:
 `nothing` unless the struct matches the `CArray` shape and its element type
-has a [`numpy_dtypes`](@ref) entry; otherwise `(; eltype, ndim, ctype,
-dtype)`, adding the element type's `ctypes` expression ([`pytypes`](@ref))
-and numpy dtype to the recognizer's fields.
+has a [`numpy_dtypes`](@ref) entry; otherwise
+`(; eltype, ndim, ownership, ctype, dtype)`, adding the element type's
+`ctypes` expression ([`pytypes`](@ref)) and numpy dtype to the recognizer's
+fields.
 """
 function _python_carray_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
     info = carray_struct_info(desc, typeinfo)
     info === nothing && return nothing
     haskey(numpy_dtypes, info.eltype) || return nothing
     return (;
-        info.eltype, info.ndim,
+        info.eltype, info.ndim, info.ownership,
         ctype = pytypes[info.eltype],
         dtype = numpy_dtypes[info.eltype],
     )
@@ -378,7 +379,7 @@ function write_wrapper(dest::PythonTarget, abi_info::ABIInfo)
             m.symbol for m in entrypoints
                 if !isempty(raw_primitive_pointer_args(m, typeinfo))
         ]
-        isempty(raw_ptr_methods) || @info "JuliaLibWrapping: entrypoints take raw `Ptr{<primitive>}` arguments; the emitted Python wrappers carry a docstring describing the layout/ownership contract. Consider wrapping these in `CArray{T,N}` (JLWInterop) for safer interop." methods = raw_ptr_methods
+        isempty(raw_ptr_methods) || @info "JuliaLibWrapping: entrypoints take raw `Ptr{<primitive>}` arguments; the emitted Python wrappers carry a docstring describing the layout/ownership contract. Consider wrapping these in `CArray{owned,T,N}` (JLWInterop) for safer interop." methods = raw_ptr_methods
     end
 
     needs_jlwerror = any(
@@ -439,15 +440,18 @@ end
 """
     _emit_free_method(f, buffers_desc, pronoun, free_lines, release_present)
 
-Emit the shared `.free()` method body used by `CArray`/`CStrArray`/`CDict`'s
-generated `ctypes.Structure` classes. Idempotent and a genuine no-op when
-`self.owned` is `0` — regardless of `release_present` — since a value that
-was never owned needs no release capability to safely no-op; only escalates
-to a `RuntimeError` when actually asked to release an owned (`owned == 1`)
-buffer the library gave no way to release. This is also what makes it safe
-for the façade to call unconditionally from a `finally` block (see
-`_emit_facade_autowrapper`): a pass-through/borrowed result's `.free()` call
-never raises.
+Emit the shared `.free()` method body used by `CStrArray`/`CDict`'s generated
+`ctypes.Structure` classes, whose ownership is a runtime `owned` field.
+Idempotent and a genuine no-op when `self.owned` is `0` — regardless of
+`release_present` — since a value that was never owned needs no release
+capability to safely no-op; only escalates to a `RuntimeError` when actually
+asked to release an owned (`owned == 1`) buffer the library gave no way to
+release. This is also what makes it safe for the façade to call
+unconditionally from a `finally` block (see `_emit_facade_autowrapper`): a
+pass-through/borrowed result's `.free()` call never raises.
+
+`CArray` carries its ownership in its type instead, and gets
+[`_emit_carray_free_method`](@ref).
 
 `buffers_desc`/`pronoun` fill in "buffer"/"it" or "buffers"/"them" in the
 docstring; `free_lines` are the release-call statements (already indented to
@@ -482,54 +486,93 @@ function _emit_free_method(
     end
 end
 
+"""
+    _emit_carray_free_method(f, release_present)
+
+Emit the `.free()` method for a `CArray{:owned,...}` class. The struct
+carries no ownership field, so idempotence rides on a Python-side `_freed`
+attribute set after the release call. Without release entrypoints the body
+raises the same `RuntimeError` as [`_emit_free_method`](@ref); the façade
+never reaches it, since an owning return is demoted to a mechanical
+re-export in that case (see [`_facade_classify_return`](@ref)), but a
+`_lowlevel` caller gets a clear diagnosis instead of an `AttributeError`.
+"""
+function _emit_carray_free_method(f::IO, release_present::Bool)
+    println(f, "")
+    println(f, "    def free(self):")
+    println(f, "        \"\"\"Free the Julia-allocated buffer.")
+    println(f, "")
+    println(f, "        Idempotent: a second call is a no-op. For callers who bypass the")
+    println(f, "        façade's convert-then-free wrapper and talk to `_lowlevel` directly.\"\"\"")
+    println(f, "        if getattr(self, \"_freed\", False):")
+    println(f, "            return")
+    if release_present
+        println(f, "        _lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))")
+        return println(f, "        self._freed = True")
+    else
+        return println(
+            f, "        raise RuntimeError(\"this library does not export release entrypoints; ",
+            "add JLWInterop.@export_release_entrypoints to the library\")"
+        )
+    end
+end
+
+"""
+    _write_carray_helpers(f, cainfo, release_present)
+
+Emit the conversion methods on a recognized `CArray` `ctypes` class. The
+class's ownership decides its API: a `:borrowed` class gets `from_numpy`
+(building a carrier over a numpy buffer the caller keeps alive) and
+`as_numpy`, and no `free()` — it never owns anything to release. An
+`:owned` class gets `as_numpy` and `free()`, and no `from_numpy` — Python
+has no Julia allocation to hand over.
+"""
 function _write_carray_helpers(f::IO, cainfo, release_present::Bool)
-    # Emit methods on the recognized CArray ctypes class. `from_numpy`
-    # borrows; `as_numpy` returns a view; the façade copies owning returns
-    # before freeing them.
     ctype = cainfo.ctype
     dtype = cainfo.dtype
     ndim = cainfo.ndim
-    # 1-D arrays accept either C- or F-contiguous (equivalent); higher rank
-    # requires Fortran order because CArray storage is column-major.
-    contig_check = ndim == 1 ?
-        "if not (arr.flags.c_contiguous or arr.flags.f_contiguous):" :
-        "if not arr.flags.f_contiguous:"
-    contig_msg = ndim == 1 ?
-        "\"array must be contiguous\"" :
-        (
-            "\"array must be Fortran-contiguous (column-major); \"\n" *
-            "                             \"use np.asfortranarray(arr) to convert\""
-        )
-    println(f, "")
-    println(f, "    @classmethod")
-    println(f, "    def from_numpy(cls, arr):")
-    println(f, "        \"\"\"Return a CArray view of the ", ndim, "-D numpy array `arr`.")
-    println(f, "")
-    if ndim == 1
-        println(f, "        Raises ValueError on ndim, contiguity, or dtype mismatch (fail-fast: no")
-        println(f, "        silent reinterpretation). The returned object holds a reference to `arr`,")
-        println(f, "        so the caller must keep it alive for the duration of any C call that uses")
-        println(f, "        the buffer.\"\"\"")
-    else
-        println(f, "        CArray storage is column-major (Julia / Fortran order). A default")
-        println(f, "        row-major (C-order) numpy array is REJECTED rather than silently")
-        println(f, "        reinterpreted — call `np.asfortranarray(arr)` first if needed.")
-        println(f, "        Raises ValueError on ndim, contiguity, or dtype mismatch. The returned")
-        println(f, "        object holds a reference to `arr`, so the caller must keep it alive for")
-        println(f, "        the duration of any C call that uses the buffer.\"\"\"")
+    if cainfo.ownership === :borrowed
+        # 1-D arrays accept either C- or F-contiguous (equivalent); higher rank
+        # requires Fortran order because CArray storage is column-major.
+        contig_check = ndim == 1 ?
+            "if not (arr.flags.c_contiguous or arr.flags.f_contiguous):" :
+            "if not arr.flags.f_contiguous:"
+        contig_msg = ndim == 1 ?
+            "\"array must be contiguous\"" :
+            (
+                "\"array must be Fortran-contiguous (column-major); \"\n" *
+                    "                             \"use np.asfortranarray(arr) to convert\""
+            )
+        println(f, "")
+        println(f, "    @classmethod")
+        println(f, "    def from_numpy(cls, arr):")
+        println(f, "        \"\"\"Return a CArray view of the ", ndim, "-D numpy array `arr`.")
+        println(f, "")
+        if ndim == 1
+            println(f, "        Raises ValueError on ndim, contiguity, or dtype mismatch (fail-fast: no")
+            println(f, "        silent reinterpretation). The returned object holds a reference to `arr`,")
+            println(f, "        so the caller must keep it alive for the duration of any C call that uses")
+            println(f, "        the buffer.\"\"\"")
+        else
+            println(f, "        CArray storage is column-major (Julia / Fortran order). A default")
+            println(f, "        row-major (C-order) numpy array is REJECTED rather than silently")
+            println(f, "        reinterpreted — call `np.asfortranarray(arr)` first if needed.")
+            println(f, "        Raises ValueError on ndim, contiguity, or dtype mismatch. The returned")
+            println(f, "        object holds a reference to `arr`, so the caller must keep it alive for")
+            println(f, "        the duration of any C call that uses the buffer.\"\"\"")
+        end
+        println(f, "        if arr.ndim != ", ndim, ":")
+        println(f, "            raise ValueError(f\"expected ", ndim, "-D array, got {arr.ndim}-D\")")
+        println(f, "        ", contig_check)
+        println(f, "            raise ValueError(", contig_msg, ")")
+        println(f, "        expected_dtype = np.dtype(", repr(dtype), ")")
+        println(f, "        if arr.dtype != expected_dtype:")
+        println(f, "            raise ValueError(f\"expected dtype ", dtype, ", got {arr.dtype}\")")
+        println(f, "        obj = cls(dims=(ctypes.c_int32 * ", ndim, ")(*arr.shape),")
+        println(f, "                  data=arr.ctypes.data_as(ctypes.POINTER(", ctype, ")))")
+        println(f, "        obj._buffer = arr")
+        println(f, "        return obj")
     end
-    println(f, "        if arr.ndim != ", ndim, ":")
-    println(f, "            raise ValueError(f\"expected ", ndim, "-D array, got {arr.ndim}-D\")")
-    println(f, "        ", contig_check)
-    println(f, "            raise ValueError(", contig_msg, ")")
-    println(f, "        expected_dtype = np.dtype(", repr(dtype), ")")
-    println(f, "        if arr.dtype != expected_dtype:")
-    println(f, "            raise ValueError(f\"expected dtype ", dtype, ", got {arr.dtype}\")")
-    println(f, "        obj = cls(dims=(ctypes.c_int32 * ", ndim, ")(*arr.shape),")
-    println(f, "                  data=arr.ctypes.data_as(ctypes.POINTER(", ctype, ")),")
-    println(f, "                  owned=0)")
-    println(f, "        obj._buffer = arr")
-    println(f, "        return obj")
     println(f, "")
     println(f, "    def as_numpy(self):")
     if ndim == 1
@@ -545,11 +588,8 @@ function _write_carray_helpers(f::IO, cainfo, release_present::Bool)
         println(f, "        # shape and strides.")
         println(f, "        return np.ctypeslib.as_array(self.data, shape=tuple(self.dims)[::-1]).T")
     end
-    return _emit_free_method(
-        f, "buffer", "it",
-        ["        _lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))"],
-        release_present
-    )
+    cainfo.ownership === :owned || return nothing
+    return _emit_carray_free_method(f, release_present)
 end
 
 function _write_cstring_helpers(f::IO)
@@ -915,7 +955,7 @@ function _write_bindings(
             println(f, "    A default numpy array is row-major (C order); passing `arr.ctypes.data`")
             println(f, "    from such an array to a Julia function that interprets it as a matrix")
             println(f, "    will see a silently transposed view. Use `np.asfortranarray(arr)` before")
-            println(f, "    taking `.ctypes.data`, or — better — wrap the field in `CArray{T,N}`")
+            println(f, "    taking `.ctypes.data`, or — better — wrap the field in `CArray{owned,T,N}`")
             println(f, "    (JLWInterop) so shape and layout travel with the buffer.")
             println(f, "    \"\"\"")
         end
@@ -944,7 +984,8 @@ end
 
 Classify a method argument for façade auto-wrapping. The return is one of:
 - `(kind=:primitive,)` — pass-through
-- `(kind=:carray, classname=…)` — wrap with `<class>.from_numpy(name)`
+- `(kind=:carray, classname=…)` — a borrowed `CArray`; wrap with
+  `<class>.from_numpy(name)`
 - `(kind=:cstring, classname=…)` — wrap with `<class>.from_str(name)`
 - `(kind=:cstrarray, classname=…)` — wrap with `<class>.from_list(name)`
 - `(kind=:cdict, classname=…)` — wrap with `<class>.from_dict(name)`
@@ -960,7 +1001,14 @@ function _facade_classify_arg(
     if t isa PrimitiveTypeDesc
         return (kind = :primitive,)
     elseif t isa StructDesc
-        if !isnothing(_python_carray_info(t, typeinfo))
+        cainfo = _python_carray_info(t, typeinfo)
+        if !isnothing(cainfo)
+            # An owning CArray argument hands Julia-allocated storage into the
+            # library, which then owns the release. numpy cannot supply that.
+            cainfo.ownership === :owned && return (
+                kind = :opaque,
+                reason = "argument transfers CArray ownership into the library; hand-wrap",
+            )
             return (kind = :carray, classname = typedict[arg.type])
         elseif cstring_struct_info(t, typeinfo)
             return (kind = :cstring, classname = typedict[arg.type])
@@ -987,19 +1035,14 @@ Classify a method's return for façade auto-wrapping. `release_present` is
 [`_release_symbols_present`](@ref)'s verdict for the surrounding library.
 The return is one of:
 - `(kind=:passthrough,)` — primitive scalar (including `Cvoid`)
-- `(kind=:carray_unwrap, classname=…)` — inside a `try`: when borrowed
-  (`_result.owned` is `0`), return `_result.as_numpy()` (zero-copy view),
-  preserving zero-copy behavior; when owned
-  (`_result.owned` is `1`), copy into a fresh numpy array
-  (`np.array(_result.as_numpy(), copy=True)`) FIRST — never hand back a view
-  over memory about to be freed. A `finally` then calls `_result.free()`
-  unconditionally (see `_emit_free_method`: idempotent, a no-op when
-  borrowed). Not gated on `release_present` (unlike `:cstrarray_unwrap`/
-  `:cdict_unwrap` below): a plain, always-borrowed `CArray` return — by far
-  the common case, predating the `owned` flag — must keep auto-wrapping even
-  when the library never calls `@export_release_entrypoints`, since
-  `.free()` only escalates to a `RuntimeError` when actually asked to
-  release an owned value.
+- `(kind=:carray_view, classname=…)` — a borrowed `CArray` return: the
+  storage belongs to the caller, so `return _result.as_numpy()` hands back a
+  zero-copy view and nothing is freed. Not gated on `release_present` — there
+  is nothing to release.
+- `(kind=:carray_unwrap, classname=…)` — an owning `CArray` return: inside a
+  `try`, copy into a fresh numpy array (`np.array(_result.as_numpy(),
+  copy=True)`) FIRST — never hand back a view over memory about to be freed
+  — then a `finally` calls `_result.free()`.
 - `(kind=:cstring_unwrap, classname=…)` — return `_result.as_str()`
 - `(kind=:cstrarray_unwrap, classname=…)` — inside a `try`: `_out =
   _result.as_list()` (a real copy, independent of the buffer); a `finally`
@@ -1014,9 +1057,9 @@ The return is one of:
   is by-value, so no free is involved (not gated on `release_present`)
 - `(kind=:jlwstatus_discard,)` — direct `JLWStatus` return; discard, return `None`
 - `(kind=:opaque, reason=…)` — bail out. Also returned in place of
-  `:cstrarray_unwrap`/`:cdict_unwrap` when `release_present` is `false`:
-  auto-wrapping an owning return with no release entrypoints available
-  would emit a call to a symbol that does not exist.
+  `:carray_unwrap`/`:cstrarray_unwrap`/`:cdict_unwrap` when `release_present`
+  is `false`: auto-wrapping an owning return with no release entrypoints
+  available would emit a call to a symbol that does not exist.
 """
 function _facade_classify_return(
         method::MethodDesc,
@@ -1028,9 +1071,16 @@ function _facade_classify_return(
     if rt isa PrimitiveTypeDesc
         return (kind = :passthrough,)
     elseif rt isa StructDesc
+        cainfo = _python_carray_info(rt, typeinfo)
         if is_jlwstatus_struct(rt, typeinfo)
             return (kind = :jlwstatus_discard,)
-        elseif !isnothing(_python_carray_info(rt, typeinfo))
+        elseif !isnothing(cainfo)
+            cainfo.ownership === :borrowed &&
+                return (kind = :carray_view, classname = typedict[method.return_type])
+            release_present || return (
+                kind = :opaque,
+                reason = "owning return needs release entrypoints; add JLWInterop.@export_release_entrypoints to the library",
+            )
             return (kind = :carray_unwrap, classname = typedict[method.return_type])
         elseif cstring_struct_info(rt, typeinfo)
             return (kind = :cstring_unwrap, classname = typedict[method.return_type])
@@ -1102,10 +1152,10 @@ function _facade_plan(
         )
     end
     uses_numpy = any(c -> c.kind === :carray, arg_classes) ||
-        ret.kind === :carray_unwrap
+        ret.kind in (:carray_view, :carray_unwrap)
     adds_value = any(c -> c.kind !== :primitive, arg_classes) ||
         ret.kind in (
-        :carray_unwrap, :cstring_unwrap, :cstrarray_unwrap,
+        :carray_view, :carray_unwrap, :cstring_unwrap, :cstrarray_unwrap,
         :cdict_unwrap, :copt_unwrap, :jlwstatus_discard,
     )
     if !adds_value
@@ -1160,15 +1210,17 @@ function _emit_facade_autowrapper(f::IO, method::MethodDesc, plan)
         # `_lowlevel` already raises JLWError on a non-zero status; the
         # façade discards the status struct and returns `None`.
         println(f, "    ", call)
+    elseif ret.kind === :carray_view
+        # The storage belongs to the caller, so the view is safe to hand back
+        # and there is nothing to release.
+        println(f, "    _result = ", call)
+        println(f, "    return _result.as_numpy()")
     elseif ret.kind === :carray_unwrap
-        # Borrowed results return a zero-copy view. Owning results are copied
-        # before the carrier is freed in `finally`.
+        # The Julia allocation is released here, so the caller gets a copy
+        # rather than a view over freed memory.
         println(f, "    _result = ", call)
         println(f, "    try:")
-        println(f, "        if _result.owned == 1:")
-        println(f, "            _out = np.array(_result.as_numpy(), copy=True)")
-        println(f, "        else:")
-        println(f, "            _out = _result.as_numpy()")
+        println(f, "        _out = np.array(_result.as_numpy(), copy=True)")
         println(f, "    finally:")
         println(f, "        _result.free()")
         println(f, "    return _out")
@@ -1231,7 +1283,7 @@ function _write_facade_stub(
     println(f)
     println(f, "This file is generated **once** by JuliaLibWrapping as a starter")
     println(f, "façade. Functions whose arguments and return are all recognized")
-    println(f, "(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)")
+    println(f, "(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)")
     println(f, "are wrapped to accept and return idiomatic Python objects (numpy")
     println(f, "arrays, `str`). Anything else is re-exported from `_lowlevel`")
     println(f, "with a `TODO` comment naming what needs hand-wrapping.")

--- a/JuliaLibWrapping/src/recognizers.jl
+++ b/JuliaLibWrapping/src/recognizers.jl
@@ -180,18 +180,49 @@ function copt_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc}
 end
 
 """
+    _carray_ownership(name::AbstractString) -> Union{Nothing, Symbol}
+
+Return the ownership recorded in the leading type parameter of a
+`CArray`/`CVector`/`CMatrix` type name — `:owned` for
+`"CVector{:owned, Float64}"`, `:borrowed` for
+`"CArray{:borrowed, Float32, 3}"`. Return `nothing` when `name` is not a
+CArray-family name or its first parameter is neither token, so that a name
+carrying no ownership is unrecognized rather than guessed at.
+"""
+function _carray_ownership(name::AbstractString)
+    prefix = nothing
+    for candidate in ("CArray{", "CVector{", "CMatrix{")
+        if startswith(name, candidate)
+            prefix = candidate
+            break
+        end
+    end
+    isnothing(prefix) && return nothing
+    rest = SubString(name, ncodeunits(prefix) + 1)
+    stop = findfirst(c -> c == ',' || c == '}', rest)
+    isnothing(stop) && return nothing
+    token = strip(SubString(rest, 1, prevind(rest, stop)))
+    token == ":owned" && return :owned
+    token == ":borrowed" && return :borrowed
+    return nothing
+end
+
+"""
     carray_struct_info(desc::StructDesc, typeinfo) -> Union{Nothing, NamedTuple}
 
-Recognize `CArray`, `CVector`, or `CMatrix` by name and field layout. On a
-match, return `(; eltype, ndim)` (the Julia name of the element type and the
-`dims` array's `count`); otherwise return `nothing`.
+Recognize `CArray`, `CVector`, or `CMatrix` by name and field layout. The
+name must carry an explicit leading ownership parameter (see
+[`_carray_ownership`](@ref)) and the layout must be exactly two fields:
+`dims`, an `NTuple` of a signed or unsigned integer type, and `data`, a
+pointer to a primitive type. On a match, return
+`(; eltype, ndim, ownership)` — the Julia name of the element type, the
+`dims` array's `count`, and `:owned` or `:borrowed`. Otherwise return
+`nothing`; ownership is never inferred from a name that does not state it.
 """
 function carray_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
-    (
-        startswith(desc.name, "CArray") || startswith(desc.name, "CVector") ||
-            startswith(desc.name, "CMatrix")
-    ) || return nothing
-    m = _match_fields(desc, ("dims", "data", "owned"))
+    ownership = _carray_ownership(desc.name)
+    isnothing(ownership) && return nothing
+    m = _match_fields(desc, ("dims", "data"))
     isnothing(m) && return nothing
     dims_type = typeinfo[m.dims.type]
     dims_type isa ArrayDesc || return nothing
@@ -202,9 +233,7 @@ function carray_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDes
     data_type isa PointerDesc || return nothing
     pointee = typeinfo[data_type.pointee_type]
     pointee isa PrimitiveTypeDesc || return nothing
-    owned_type = typeinfo[m.owned.type]
-    owned_type isa PrimitiveTypeDesc && owned_type.name == "Int32" || return nothing
-    return (; eltype = pointee.name, ndim = dims_type.count)
+    return (; eltype = pointee.name, ndim = dims_type.count, ownership)
 end
 
 """

--- a/JuliaLibWrapping/test/bindinginfo_carray3.json
+++ b/JuliaLibWrapping/test/bindinginfo_carray3.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Hand-authored fixture for CArray{T,3} — locks in coverage of higher-rank arrays beyond the CVector (N=1) and CMatrix (N=2) special cases. Mirrors the layout juliac would emit for `struct CArray{Float64,3}; dims::NTuple{3,Int32}; data::Ptr{Float64}; owned::Int32; end` with a single @ccallable function consuming one. The Python emitter must recognize this shape and emit the rank-agnostic from_numpy/as_numpy/free helpers (column-major).",
+  "_comment": "Hand-authored fixture for CArray{owned,T,3} — locks in coverage of higher-rank arrays beyond the CVector (N=1) and CMatrix (N=2) special cases. Mirrors the layout juliac emits for `struct CArray{:borrowed,Float64,3}; dims::NTuple{3,Int32}; data::Ptr{Float64}; end` with a single @ccallable function consuming one. The Python emitter must recognize this shape and emit the rank-agnostic, borrowed-flavored from_numpy/as_numpy helpers (column-major, no free).",
   "types": [
     {
       "kind": "primitive",
@@ -36,13 +36,12 @@
     },
     {
       "kind": "struct",
-      "name": "CArray{Float64, 3}",
+      "name": "CArray{:borrowed, Float64, 3}",
       "id": 4,
-      "size": 32,
+      "size": 24,
       "fields": [
         { "name": "dims", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 3, "offset": 16, "isptr": false, "isfieldatomic": false },
-        { "name": "owned", "type_id": 2, "offset": 24, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 3, "offset": 16, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     }
@@ -50,7 +49,7 @@
   "functions": [
     {
       "returns": { "type_id": 1 },
-      "name": "sum3d(a::CArray{Float64, 3})",
+      "name": "sum3d(a::CArray{:borrowed, Float64, 3})",
       "arguments": [
         { "name": "a", "type_id": 4 }
       ],

--- a/JuliaLibWrapping/test/bindinginfo_carray_owned_nofree.json
+++ b/JuliaLibWrapping/test/bindinginfo_carray_owned_nofree.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Hand-authored fixture for an owning CArray return. Mirrors the layout juliac emits for `struct CVector{:owned,Float64}; dims::NTuple{1,Int32}; data::Ptr{Float64}; end`, with one @ccallable function returning a freshly allocated CVector{:owned, Float64}, plus the macro-emitted jlw_free/jlw_free_strings release entrypoints so the owning return is `:auto` (copy, then free in a `finally`), not `:mechanical`. No CArray-consuming function is needed here — carray3/cmatrix/libsimple already cover the borrowed-argument path; this fixture exists solely to exercise the owning-return facade shape.",
+  "_comment": "Fixture identical to bindinginfo_carray_owned.json EXCEPT the two jlw_free* release-entrypoint function entries are deleted (the `types` array — including the synthetic `Nothing`/`Ptr{Nothing}` pair those functions used — is left untouched deliberately). This models a library that returns an owning `CVector{:owned, Float64}` but forgot (or has not yet called) `JLWInterop.@export_release_entrypoints`. `_release_symbols_present` must see that `jlw_free`/`jlw_free_strings` are absent from `functions` and gate the owning return `give_vec` back to `:mechanical` with a TODO naming `JLWInterop.@export_release_entrypoints`, exactly as for CStrArray and CDict.",
   "types": [
     {
       "kind": "primitive",
@@ -107,23 +107,6 @@
       "name": "give_vec()",
       "arguments": [],
       "symbol": "give_vec"
-    },
-    {
-      "returns": { "type_id": 11 },
-      "name": "jlw_free(p::Ptr{Nothing})",
-      "arguments": [
-        { "name": "p", "type_id": 12 }
-      ],
-      "symbol": "jlw_free"
-    },
-    {
-      "returns": { "type_id": 11 },
-      "name": "jlw_free_strings(p::Ptr{CString}, n::Int64)",
-      "arguments": [
-        { "name": "p", "type_id": 10 },
-        { "name": "n", "type_id": 3 }
-      ],
-      "symbol": "jlw_free_strings"
     }
   ]
 }

--- a/JuliaLibWrapping/test/bindinginfo_cmatrix.json
+++ b/JuliaLibWrapping/test/bindinginfo_cmatrix.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Hand-authored fixture for the CMatrix vocabulary type (CMatrix{T} = CArray{T,2}). Mirrors the layout juliac would emit for `struct CMatrix{Float64}; dims::NTuple{2,Int32}; data::Ptr{Float64}; owned::Int32; end` with a single @ccallable function consuming one. The Python emitter must recognize this shape by name + field layout and emit numpy from_numpy/as_numpy/free helpers (column-major).",
+  "_comment": "Hand-authored fixture for the CMatrix vocabulary type (CMatrix{owned,T} = CArray{owned,T,2}). Mirrors the layout juliac emits for `struct CMatrix{:borrowed,Float64}; dims::NTuple{2,Int32}; data::Ptr{Float64}; end` with a single @ccallable function consuming one. The Python emitter must recognize this shape by name + field layout and emit the borrowed-flavored numpy from_numpy/as_numpy helpers (column-major, no free).",
   "types": [
     {
       "kind": "primitive",
@@ -36,13 +36,12 @@
     },
     {
       "kind": "struct",
-      "name": "CMatrix{Float64}",
+      "name": "CMatrix{:borrowed, Float64}",
       "id": 4,
-      "size": 24,
+      "size": 16,
       "fields": [
         { "name": "dims", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false },
-        { "name": "owned", "type_id": 2, "offset": 16, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     }
@@ -50,7 +49,7 @@
   "functions": [
     {
       "returns": { "type_id": 1 },
-      "name": "trace_cmatrix(m::CMatrix{Float64})",
+      "name": "trace_cmatrix(m::CMatrix{:borrowed, Float64})",
       "arguments": [
         { "name": "m", "type_id": 4 }
       ],

--- a/JuliaLibWrapping/test/bindinginfo_libsimple.json
+++ b/JuliaLibWrapping/test/bindinginfo_libsimple.json
@@ -49,7 +49,7 @@
     {
       "id": 3,
       "kind": "struct",
-      "name": "CVector{CTree{Float64}}",
+      "name": "CVector{:borrowed, CTree{Float64}}",
       "size": 16,
       "alignment": 8,
       "fields": [
@@ -104,13 +104,12 @@
     {
       "id": 9,
       "kind": "struct",
-      "name": "CVector{Float32}",
-      "size": 24,
+      "name": "CVector{:borrowed, Float32}",
+      "size": 16,
       "alignment": 8,
       "fields": [
         { "name": "dims", "type_id": 13, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 10, "offset": 8, "isptr": false, "isfieldatomic": false },
-        { "name": "owned", "type_id": 4, "offset": 16, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 10, "offset": 8, "isptr": false, "isfieldatomic": false }
       ]
     },
     {

--- a/JuliaLibWrapping/test/expected_carray3_facade.py
+++ b/JuliaLibWrapping/test/expected_carray3_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.
@@ -17,11 +17,11 @@ from . import _lowlevel  # noqa: F401
 import numpy as np  # noqa: F401
 
 from ._lowlevel import (
-    CArray_Float64_3,
+    CArray_borrowed_Float64_3,
 )
 
 def sum3d(a):
-    _a = CArray_Float64_3.from_numpy(a)
+    _a = CArray_borrowed_Float64_3.from_numpy(a)
     return _lowlevel.sum3d(_a)
 
-__all__ = ["CArray_Float64_3", "sum3d"]
+__all__ = ["CArray_borrowed_Float64_3", "sum3d"]

--- a/JuliaLibWrapping/test/expected_carray3_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_carray3_lowlevel.py
@@ -54,11 +54,10 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     )
 _jlw_loaded.add(_jlw_this_pkg)
 
-class CArray_Float64_3(ctypes.Structure):
+class CArray_borrowed_Float64_3(ctypes.Structure):
     _fields_ = [
         ("dims", (ctypes.c_int32 * 3)),
         ("data", ctypes.POINTER(ctypes.c_double)),
-        ("owned", ctypes.c_int32),
     ]
 
     @classmethod
@@ -80,8 +79,7 @@ class CArray_Float64_3(ctypes.Structure):
         if arr.dtype != expected_dtype:
             raise ValueError(f"expected dtype float64, got {arr.dtype}")
         obj = cls(dims=(ctypes.c_int32 * 3)(*arr.shape),
-                  data=arr.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-                  owned=0)
+                  data=arr.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
         obj._buffer = arr
         return obj
 
@@ -95,17 +93,7 @@ class CArray_Float64_3(ctypes.Structure):
         # shape and strides.
         return np.ctypeslib.as_array(self.data, shape=tuple(self.dims)[::-1]).T
 
-    def free(self):
-        """Free the Julia-allocated buffer iff this object owns it (owned is 1).
-
-        Idempotent: a second call, or a call on a borrowed (owned is 0) value, is a
-        no-op. For callers who bypass the façade's convert-then-free wrapper and
-        talk to `_lowlevel` directly."""
-        if self.owned != 1:
-            return
-        raise RuntimeError("this library does not export release entrypoints; add JLWInterop.@export_release_entrypoints to the library")
-
-_lib.sum3d.argtypes = [CArray_Float64_3]
+_lib.sum3d.argtypes = [CArray_borrowed_Float64_3]
 _lib.sum3d.restype = ctypes.c_double
 def sum3d(a):
     return _lib.sum3d(a)

--- a/JuliaLibWrapping/test/expected_carray_owned_facade.py
+++ b/JuliaLibWrapping/test/expected_carray_owned_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.
@@ -19,18 +19,15 @@ import numpy as np  # noqa: F401
 from ._lowlevel import (
     Nothing,
     CString,
-    CVector_Float64,
+    CVector_owned_Float64,
 )
 
 def give_vec():
     _result = _lowlevel.give_vec()
     try:
-        if _result.owned == 1:
-            _out = np.array(_result.as_numpy(), copy=True)
-        else:
-            _out = _result.as_numpy()
+        _out = np.array(_result.as_numpy(), copy=True)
     finally:
         _result.free()
     return _out
 
-__all__ = ["Nothing", "CString", "CVector_Float64", "give_vec"]
+__all__ = ["Nothing", "CString", "CVector_owned_Float64", "give_vec"]

--- a/JuliaLibWrapping/test/expected_carray_owned_nofree_facade.py
+++ b/JuliaLibWrapping/test/expected_carray_owned_nofree_facade.py
@@ -1,4 +1,4 @@
-"""cstring_demo idiomatic façade.
+"""carray_owned_nofree_demo idiomatic façade.
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
@@ -16,15 +16,11 @@ on every `write_wrapper` call.
 from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
+    Nothing,
     CString,
+    CVector_owned_Float64,
 )
 
-def greeting_length(s):
-    _s = CString.from_str(s)
-    return _lowlevel.greeting_length(_s)
+from ._lowlevel import give_vec  # TODO: hand-wrap — owning return needs release entrypoints; add JLWInterop.@export_release_entrypoints to the library
 
-def greeting():
-    _result = _lowlevel.greeting()
-    return _result.as_str()
-
-__all__ = ["CString", "greeting_length", "greeting"]
+__all__ = ["Nothing", "CString", "CVector_owned_Float64", "give_vec"]

--- a/JuliaLibWrapping/test/expected_carray_owned_nofree_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_carray_owned_nofree_lowlevel.py
@@ -6,8 +6,8 @@ import pathlib
 import numpy as np
 
 _HERE = pathlib.Path(__file__).resolve().parent
-_LIBRARY_BASENAME = "libcarrayowned"
-_LIBRARY_ENV_VAR = "CARRAY_OWNED_DEMO_LIBRARY"
+_LIBRARY_BASENAME = "libcarrayownednofree"
+_LIBRARY_ENV_VAR = "CARRAY_OWNED_NOFREE_DEMO_LIBRARY"
 
 def _resolve_library_path():
     override = os.environ.get(_LIBRARY_ENV_VAR)
@@ -111,17 +111,10 @@ class CVector_owned_Float64(ctypes.Structure):
         façade's convert-then-free wrapper and talk to `_lowlevel` directly."""
         if getattr(self, "_freed", False):
             return
-        _lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))
-        self._freed = True
+        raise RuntimeError("this library does not export release entrypoints; add JLWInterop.@export_release_entrypoints to the library")
 
 _lib.give_vec.argtypes = []
 _lib.give_vec.restype = CVector_owned_Float64
 def give_vec():
     return _lib.give_vec()
-
-_lib.jlw_free.argtypes = [ctypes.c_void_p]
-_lib.jlw_free.restype = None
-
-_lib.jlw_free_strings.argtypes = [ctypes.POINTER(CString), ctypes.c_int64]
-_lib.jlw_free_strings.restype = None
 

--- a/JuliaLibWrapping/test/expected_cdict_facade.py
+++ b/JuliaLibWrapping/test/expected_cdict_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_cdict_int32_facade.py
+++ b/JuliaLibWrapping/test/expected_cdict_int32_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_cmatrix_facade.py
+++ b/JuliaLibWrapping/test/expected_cmatrix_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.
@@ -17,11 +17,11 @@ from . import _lowlevel  # noqa: F401
 import numpy as np  # noqa: F401
 
 from ._lowlevel import (
-    CMatrix_Float64,
+    CMatrix_borrowed_Float64,
 )
 
 def trace_cmatrix(m):
-    _m = CMatrix_Float64.from_numpy(m)
+    _m = CMatrix_borrowed_Float64.from_numpy(m)
     return _lowlevel.trace_cmatrix(_m)
 
-__all__ = ["CMatrix_Float64", "trace_cmatrix"]
+__all__ = ["CMatrix_borrowed_Float64", "trace_cmatrix"]

--- a/JuliaLibWrapping/test/expected_cmatrix_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cmatrix_lowlevel.py
@@ -54,11 +54,10 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     )
 _jlw_loaded.add(_jlw_this_pkg)
 
-class CMatrix_Float64(ctypes.Structure):
+class CMatrix_borrowed_Float64(ctypes.Structure):
     _fields_ = [
         ("dims", (ctypes.c_int32 * 2)),
         ("data", ctypes.POINTER(ctypes.c_double)),
-        ("owned", ctypes.c_int32),
     ]
 
     @classmethod
@@ -80,8 +79,7 @@ class CMatrix_Float64(ctypes.Structure):
         if arr.dtype != expected_dtype:
             raise ValueError(f"expected dtype float64, got {arr.dtype}")
         obj = cls(dims=(ctypes.c_int32 * 2)(*arr.shape),
-                  data=arr.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-                  owned=0)
+                  data=arr.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
         obj._buffer = arr
         return obj
 
@@ -95,17 +93,7 @@ class CMatrix_Float64(ctypes.Structure):
         # shape and strides.
         return np.ctypeslib.as_array(self.data, shape=tuple(self.dims)[::-1]).T
 
-    def free(self):
-        """Free the Julia-allocated buffer iff this object owns it (owned is 1).
-
-        Idempotent: a second call, or a call on a borrowed (owned is 0) value, is a
-        no-op. For callers who bypass the façade's convert-then-free wrapper and
-        talk to `_lowlevel` directly."""
-        if self.owned != 1:
-            return
-        raise RuntimeError("this library does not export release entrypoints; add JLWInterop.@export_release_entrypoints to the library")
-
-_lib.trace_cmatrix.argtypes = [CMatrix_Float64]
+_lib.trace_cmatrix.argtypes = [CMatrix_borrowed_Float64]
 _lib.trace_cmatrix.restype = ctypes.c_double
 def trace_cmatrix(m):
     return _lib.trace_cmatrix(m)

--- a/JuliaLibWrapping/test/expected_copt_facade.py
+++ b/JuliaLibWrapping/test/expected_copt_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_cstrarray_facade.py
+++ b/JuliaLibWrapping/test/expected_cstrarray_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_cstrarray_nofree_facade.py
+++ b/JuliaLibWrapping/test/expected_cstrarray_nofree_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_jlwstatus_facade.py
+++ b/JuliaLibWrapping/test/expected_jlwstatus_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_libsimple_facade.py
+++ b/JuliaLibWrapping/test/expected_libsimple_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.
@@ -17,9 +17,9 @@ from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
     MyTwoVec,
-    CVector_Float32,
+    CVector_borrowed_Float32,
     CVectorPair_Float32,
-    CVector_CTree_Float64,
+    CVector_borrowed_CTree_Float64,
     CTree_Float64,
 )
 
@@ -27,4 +27,4 @@ from ._lowlevel import tree_size  # TODO: hand-wrap — `tree`: argument has unr
 from ._lowlevel import copyto_and_sum  # TODO: hand-wrap — `fromto`: argument has unrecognized type `CVectorPair{Float32}`
 from ._lowlevel import countsame  # TODO: hand-wrap — `list`: argument has raw pointer type `Ptr{MyTwoVec}`
 
-__all__ = ["MyTwoVec", "CVector_Float32", "CVectorPair_Float32", "CVector_CTree_Float64", "CTree_Float64", "tree_size", "copyto_and_sum", "countsame"]
+__all__ = ["MyTwoVec", "CVector_borrowed_Float32", "CVectorPair_Float32", "CVector_borrowed_CTree_Float64", "CTree_Float64", "tree_size", "copyto_and_sum", "countsame"]

--- a/JuliaLibWrapping/test/expected_libsimple_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_libsimple_lowlevel.py
@@ -64,11 +64,10 @@ class MyTwoVec(ctypes.Structure):
         ("y", ctypes.c_int32),
     ]
 
-class CVector_Float32(ctypes.Structure):
+class CVector_borrowed_Float32(ctypes.Structure):
     _fields_ = [
         ("dims", (ctypes.c_int32 * 1)),
         ("data", ctypes.POINTER(ctypes.c_float)),
-        ("owned", ctypes.c_int32),
     ]
 
     @classmethod
@@ -87,8 +86,7 @@ class CVector_Float32(ctypes.Structure):
         if arr.dtype != expected_dtype:
             raise ValueError(f"expected dtype float32, got {arr.dtype}")
         obj = cls(dims=(ctypes.c_int32 * 1)(*arr.shape),
-                  data=arr.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
-                  owned=0)
+                  data=arr.ctypes.data_as(ctypes.POINTER(ctypes.c_float)))
         obj._buffer = arr
         return obj
 
@@ -96,30 +94,20 @@ class CVector_Float32(ctypes.Structure):
         """Return a 1-D numpy view of the underlying buffer (no copy)."""
         return np.ctypeslib.as_array(self.data, shape=(self.dims[0],))
 
-    def free(self):
-        """Free the Julia-allocated buffer iff this object owns it (owned is 1).
-
-        Idempotent: a second call, or a call on a borrowed (owned is 0) value, is a
-        no-op. For callers who bypass the façade's convert-then-free wrapper and
-        talk to `_lowlevel` directly."""
-        if self.owned != 1:
-            return
-        raise RuntimeError("this library does not export release entrypoints; add JLWInterop.@export_release_entrypoints to the library")
-
 class CVectorPair_Float32(ctypes.Structure):
     _fields_ = [
-        ("from_", CVector_Float32),
-        ("to", CVector_Float32),
+        ("from_", CVector_borrowed_Float32),
+        ("to", CVector_borrowed_Float32),
     ]
 
-class CVector_CTree_Float64(ctypes.Structure):
+class CVector_borrowed_CTree_Float64(ctypes.Structure):
     _fields_ = [
         ("dims", (ctypes.c_int32 * 1)),
         ("data", ctypes.POINTER(CTree_Float64)),
     ]
 
 CTree_Float64._fields_ = [
-    ("children", CVector_CTree_Float64),
+    ("children", CVector_borrowed_CTree_Float64),
 ]
 
 _lib.tree_size.argtypes = [CTree_Float64]

--- a/JuliaLibWrapping/test/expected_rawptr_facade.py
+++ b/JuliaLibWrapping/test/expected_rawptr_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_rawptr_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_rawptr_lowlevel.py
@@ -64,7 +64,7 @@ def sum_doubles(data, n):
     A default numpy array is row-major (C order); passing `arr.ctypes.data`
     from such an array to a Julia function that interprets it as a matrix
     will see a silently transposed view. Use `np.asfortranarray(arr)` before
-    taking `.ctypes.data`, or — better — wrap the field in `CArray{T,N}`
+    taking `.ctypes.data`, or — better — wrap the field in `CArray{owned,T,N}`
     (JLWInterop) so shape and layout travel with the buffer.
     """
     return _lib.sum_doubles(data, n)

--- a/JuliaLibWrapping/test/runtests.jl
+++ b/JuliaLibWrapping/test/runtests.jl
@@ -47,15 +47,15 @@ end
         @test tdesc.name == "CVectorPair{Float32}"
         @test length(tdesc.fields) == 2
         @test tdesc.fields[1].name == "from"
-        @test typeinfo[tdesc.fields[1].type].name == "CVector{Float32}"
+        @test typeinfo[tdesc.fields[1].type].name == "CVector{:borrowed, Float32}"
         @test tdesc.fields[1].offset == 0
         @test tdesc.fields[2].name == "to"
-        @test typeinfo[tdesc.fields[2].type].name == "CVector{Float32}"
+        @test typeinfo[tdesc.fields[2].type].name == "CVector{:borrowed, Float32}"
         @test tdesc.fields[2].offset == 16
         @test tdesc.size == 32
-        tdesc = typeinfo[findtype(typeinfo, "CVector{Float32}")]
-        @test tdesc.name == "CVector{Float32}"
-        @test length(tdesc.fields) == 3
+        tdesc = typeinfo[findtype(typeinfo, "CVector{:borrowed, Float32}")]
+        @test tdesc.name == "CVector{:borrowed, Float32}"
+        @test length(tdesc.fields) == 2
         @test tdesc.fields[1].name == "dims"
         dims_desc = typeinfo[tdesc.fields[1].type]
         @test dims_desc isa ArrayDesc
@@ -65,10 +65,7 @@ end
         @test tdesc.fields[2].name == "data"
         @test typeinfo[tdesc.fields[2].type].name == "Ptr{Float32}"
         @test tdesc.fields[2].offset == 8
-        @test tdesc.fields[3].name == "owned"
-        @test typeinfo[tdesc.fields[3].type].name == "Int32"
-        @test tdesc.fields[3].offset == 16
-        @test tdesc.size == 24
+        @test tdesc.size == 16
         tdesc = typeinfo[findtype(typeinfo, "MyTwoVec")]
         @test tdesc.name == "MyTwoVec"
         @test length(tdesc.fields) == 2
@@ -80,7 +77,7 @@ end
         @test tdesc.fields[2].offset == 4
         @test tdesc.size == 8
         name2idx = Dict(desc.name => i for (i, desc) in enumerate(values(typeinfo)))
-        @test name2idx["CVectorPair{Float32}"] > name2idx["CVector{Float32}"]
+        @test name2idx["CVectorPair{Float32}"] > name2idx["CVector{:borrowed, Float32}"]
     end
 
     @testset "parse_abi_info: malformed input" begin
@@ -218,11 +215,11 @@ end
             @test occursin("#include <stddef.h>", content)
             @test occursin("#include <stdint.h>", content)
             @test occursin("#include <stdbool.h>", content)
-            @test occursin("typedef struct CVector_Float32 {", content)
+            @test occursin("typedef struct CVector_borrowed_Float32 {", content)
             @test occursin("    int32_t dims[1];", content)
             @test occursin("    float* data;", content)
-            @test occursin("CVector_Float32 from;", content)
-            @test occursin("CVector_Float32 to;", content)
+            @test occursin("CVector_borrowed_Float32 from;", content)
+            @test occursin("CVector_borrowed_Float32 to;", content)
             @test occursin("float copyto_and_sum(CVectorPair_Float32 fromto);", content)
             @test occursin("int32_t countsame(MyTwoVec* list, int32_t n);", content)
         end
@@ -280,12 +277,12 @@ end
             @test occursin("import ctypes", bindings)
             @test occursin("_LIBRARY_ENV_VAR = \"LIBSIMPLE_LIBRARY\"", bindings)
             @test occursin("class CTree_Float64(ctypes.Structure):\n    pass", bindings)
-            @test occursin("class CVector_Float32(ctypes.Structure):", bindings)
+            @test occursin("class CVector_borrowed_Float32(ctypes.Structure):", bindings)
             @test occursin("(\"dims\", (ctypes.c_int32 * 1))", bindings)
             @test occursin("(\"data\", ctypes.POINTER(ctypes.c_float))", bindings)
             # `from` is a Python keyword; it must be renamed to be reachable
             # via attribute access.
-            @test occursin("(\"from_\", CVector_Float32)", bindings)
+            @test occursin("(\"from_\", CVector_borrowed_Float32)", bindings)
             @test occursin("CTree_Float64._fields_ = [", bindings)
             @test occursin("_lib.copyto_and_sum.argtypes = [CVectorPair_Float32]", bindings)
             @test occursin("_lib.copyto_and_sum.restype = ctypes.c_float", bindings)
@@ -300,7 +297,7 @@ end
             @test occursin("def as_numpy(self):", bindings)
             @test occursin("expected_dtype = np.dtype(\"float32\")", bindings)
             @test occursin("ctypes.POINTER(ctypes.c_float)", bindings)
-            # The CVector_CTree_Float64 class has a struct pointee, so the
+            # The CVector_borrowed_CTree_Float64 class has a struct pointee, so the
             # recognizer must reject it (no helper emission). There is only
             # one `from_numpy` definition in the file.
             @test count(s -> occursin("def from_numpy", s), split(bindings, '\n')) == 1
@@ -483,32 +480,36 @@ end
     end
 
     @testset "carray_struct_info" begin
-        # Structural recognition of the CArray{T,N} shape: a struct named
-        # CArray/CVector/CMatrix (since `CVector = CArray{_,1}` and
-        # `CMatrix = CArray{_,2}` may print under either name) with `dims`
-        # (NTuple{N,Int32} → ArrayDesc), `data` (Ptr{T}), and `owned`
-        # (Int32 explicit-ownership discriminant) fields, for any primitive
-        # T. The recognizer reports T's Julia name; `_python_carray_info`
-        # decides whether numpy supports it.
+        # Structural recognition of the CArray{owned,T,N} shape: a struct named
+        # CArray/CVector/CMatrix (since `CVector = CArray{_,_,1}` and
+        # `CMatrix = CArray{_,_,2}` may print under either name) whose first
+        # type parameter is `:owned` or `:borrowed`, with exactly the `dims`
+        # (NTuple{N,Int32} → ArrayDesc) and `data` (Ptr{T}) fields, for any
+        # primitive T. The recognizer reports T's Julia name and the
+        # ownership; `_python_carray_info` decides whether numpy supports the
+        # element type.
         cainfo(desc, typeinfo) = JuliaLibWrapping.carray_struct_info(desc, typeinfo)
         pycainfo(desc, typeinfo) = JuliaLibWrapping._python_carray_info(desc, typeinfo)
 
-        # libsimple exercises CVector{Float32} (N=1, primitive pointee, match)
-        # and CVector{CTree{Float64}} (struct pointee, no match).
+        # libsimple exercises CVector{:borrowed, Float32} (N=1, primitive
+        # pointee, match) and CVector{:borrowed, CTree{Float64}} (struct
+        # pointee, no match).
         abi = read_abi_info("bindinginfo_libsimple.json")
         findtype(descs, name) = (
             k = collect(keys(descs));
             k[findfirst((id) -> descs[id].name === name, k)]
         )
-        cv_f32 = abi.typeinfo[findtype(abi.typeinfo, "CVector{Float32}")]
-        cv_tree = abi.typeinfo[findtype(abi.typeinfo, "CVector{CTree{Float64}}")]
+        cv_f32 = abi.typeinfo[findtype(abi.typeinfo, "CVector{:borrowed, Float32}")]
+        cv_tree = abi.typeinfo[findtype(abi.typeinfo, "CVector{:borrowed, CTree{Float64}}")]
         info = cainfo(cv_f32, abi.typeinfo)
         @test info !== nothing
         @test info.eltype == "Float32"
         @test info.ndim == 1
+        @test info.ownership === :borrowed
         pyinfo = pycainfo(cv_f32, abi.typeinfo)
         @test pyinfo.eltype == "Float32"
         @test pyinfo.ndim == 1
+        @test pyinfo.ownership === :borrowed
         @test pyinfo.dtype == "float32"
         @test pyinfo.ctype == "ctypes.c_float"
         # Struct pointee → no match: `data` must point at a primitive.
@@ -517,24 +518,49 @@ end
 
         # cmatrix fixture exercises the N=2 case under the CMatrix alias name.
         abi_cm = read_abi_info("bindinginfo_cmatrix.json")
-        cm_f64 = abi_cm.typeinfo[findtype(abi_cm.typeinfo, "CMatrix{Float64}")]
+        cm_f64 = abi_cm.typeinfo[findtype(abi_cm.typeinfo, "CMatrix{:borrowed, Float64}")]
         info2 = cainfo(cm_f64, abi_cm.typeinfo)
         @test info2 !== nothing
         @test info2.eltype == "Float64"
         @test info2.ndim == 2
+        @test info2.ownership === :borrowed
 
         # carray3 fixture exercises N=3 under the CArray name directly.
         abi_c3 = read_abi_info("bindinginfo_carray3.json")
-        ca_f64_3 = abi_c3.typeinfo[findtype(abi_c3.typeinfo, "CArray{Float64, 3}")]
+        ca_f64_3 = abi_c3.typeinfo[findtype(abi_c3.typeinfo, "CArray{:borrowed, Float64, 3}")]
         info3 = cainfo(ca_f64_3, abi_c3.typeinfo)
         @test info3 !== nothing
         @test info3.eltype == "Float64"
         @test info3.ndim == 3
+        @test info3.ownership === :borrowed
 
-        # Hand-built rejections: wrong name, wrong field names, non-integer
-        # dims element, dims-as-primitive (not array), missing owned, owned
-        # present but wrong type. Plus a Bool-pointee CArray, which is a
-        # structural match the Python adapter declines.
+        # carray_owned fixture exercises the `:owned` token.
+        abi_co = read_abi_info("bindinginfo_carray_owned.json")
+        cv_owned = abi_co.typeinfo[findtype(abi_co.typeinfo, "CVector{:owned, Float64}")]
+        info4 = cainfo(cv_owned, abi_co.typeinfo)
+        @test info4 !== nothing
+        @test info4.eltype == "Float64"
+        @test info4.ndim == 1
+        @test info4.ownership === :owned
+
+        # Ownership token parsing, independent of layout.
+        ownership = JuliaLibWrapping._carray_ownership
+        @test ownership("CVector{:owned, Float64}") === :owned
+        @test ownership("CMatrix{:borrowed, Float32}") === :borrowed
+        @test ownership("CArray{:owned, Float64, 3}") === :owned
+        @test ownership("CVector{:owned}") === :owned
+        @test ownership("CArray{ :borrowed , Float64, 3}") === :borrowed
+        @test ownership("CVector{Float64}") === nothing        # no token at all # noidiom
+        @test ownership("CArray{Float64, 3}") === nothing      # noidiom
+        @test ownership("CVector{:mine, Float64}") === nothing # unknown token # noidiom
+        @test ownership("CVector") === nothing                 # brace required # noidiom
+        @test ownership("MyCVector{:owned, Float64}") === nothing  # noidiom
+        @test ownership("CVector{") === nothing                # unterminated # noidiom
+
+        # Hand-built rejections: tokenless name, wrong name, wrong field names,
+        # non-integer dims element, dims-as-primitive (not array), and the
+        # three-field pre-type-parameter layout. Plus a Bool-pointee CArray,
+        # which is a structural match the Python adapter declines.
         primint = PrimitiveTypeDesc("Int32", true, 32, 4, 4)
         primflt = PrimitiveTypeDesc("Float32", true, 32, 4, 4)
         primbool = PrimitiveTypeDesc("Bool", false, 8, 1, 1)
@@ -546,69 +572,62 @@ end
             1 => primint, 2 => primflt, 3 => ptr_to_flt,
             4 => arr_int32_1, 5 => arr_flt_1,
             6 => StructDesc(
-                "CVector{Float32}", 24, 8, FieldDesc[
+                "CVector{:borrowed, Float32}", 16, 8, FieldDesc[
                     FieldDesc("dims", 4, 0),
                     FieldDesc("data", 3, 8),
-                    FieldDesc("owned", 1, 16),
                 ]
             ),
             7 => primbool,
             8 => arr_bool_1,
             9 => StructDesc(
-                "NotACArray", 24, 8, FieldDesc[
+                "NotACArray{:borrowed, Float32}", 16, 8, FieldDesc[
                     FieldDesc("dims", 4, 0),
                     FieldDesc("data", 3, 8),
-                    FieldDesc("owned", 1, 16),
                 ]
             ),
             10 => StructDesc("CVectorEmpty", 0, 0, FieldDesc[]),
             11 => StructDesc(
-                "CVectorBadNames", 24, 8, FieldDesc[
+                "CVector{:borrowed, Float32}", 16, 8, FieldDesc[
                     FieldDesc("len", 4, 0),
                     FieldDesc("data", 3, 8),
-                    FieldDesc("owned", 1, 16),
                 ]
             ),
             12 => StructDesc(
-                "CVectorFloatDims", 24, 8, FieldDesc[
+                "CVector{:borrowed, Float32}", 16, 8, FieldDesc[
                     FieldDesc("dims", 5, 0),  # NTuple{1,Float32} — not Int*
                     FieldDesc("data", 3, 8),
-                    FieldDesc("owned", 1, 16),
                 ]
             ),
             13 => StructDesc(
-                "CVectorPrimDims", 24, 8, FieldDesc[
+                "CVector{:borrowed, Float32}", 16, 8, FieldDesc[
                     FieldDesc("dims", 1, 0),  # primitive Int32, not ArrayDesc
                     FieldDesc("data", 3, 8),
-                    FieldDesc("owned", 1, 16),
                 ]
             ),
             14 => StructDesc(
-                "CVectorBoolDims", 24, 8, FieldDesc[
+                "CVector{:borrowed, Float32}", 16, 8, FieldDesc[
                     FieldDesc("dims", 8, 0),  # Bool element — not Int/UInt
                     FieldDesc("data", 3, 8),
-                    FieldDesc("owned", 1, 16),
                 ]
             ),
             15 => StructDesc(
-                "CVectorNoOwned", 16, 8, FieldDesc[
+                "CVector{Float32}", 16, 8, FieldDesc[   # no ownership token
                     FieldDesc("dims", 4, 0),
                     FieldDesc("data", 3, 8),
                 ]
             ),
             16 => StructDesc(
-                "CVectorOwnedWrongType", 24, 8, FieldDesc[
+                "CVector{:borrowed, Float32}", 24, 8, FieldDesc[
                     FieldDesc("dims", 4, 0),
                     FieldDesc("data", 3, 8),
-                    FieldDesc("owned", 2, 16),  # Float32, not Int32
+                    FieldDesc("owned", 1, 16),   # runtime flag: no longer part of the layout
                 ]
             ),
             17 => PointerDesc("Ptr{Bool}", 7),
             18 => StructDesc(
-                "CVector{Bool}", 24, 8, FieldDesc[
+                "CVector{:owned, Bool}", 16, 8, FieldDesc[
                     FieldDesc("dims", 4, 0),
                     FieldDesc("data", 17, 8),
-                    FieldDesc("owned", 1, 16),
                 ]
             ),
         )
@@ -619,8 +638,8 @@ end
         @test cainfo(ti[12], ti) === nothing  # non-integer dims element # noidiom
         @test cainfo(ti[13], ti) === nothing  # dims is primitive, not ArrayDesc # noidiom
         @test cainfo(ti[14], ti) === nothing  # Bool dims element rejected # noidiom
-        @test cainfo(ti[15], ti) === nothing  # owned missing entirely # noidiom
-        @test cainfo(ti[16], ti) === nothing  # owned present but not Int32 # noidiom
+        @test cainfo(ti[15], ti) === nothing  # name states no ownership # noidiom
+        @test cainfo(ti[16], ti) === nothing  # three-field layout rejected # noidiom
 
         # Bool element: matches structurally, but `Bool` has no
         # `numpy_dtypes` entry, so the Python adapter rejects it.
@@ -628,12 +647,12 @@ end
         @test info_bool !== nothing
         @test info_bool.eltype == "Bool"
         @test info_bool.ndim == 1
+        @test info_bool.ownership === :owned
         @test pycainfo(ti[18], ti) === nothing  # noidiom
 
         # Field order may be any permutation.
         flipped = StructDesc(
-            "CVector{Float32}", 24, 8, FieldDesc[
-                FieldDesc("owned", 1, 16),
+            "CVector{:borrowed, Float32}", 16, 8, FieldDesc[
                 FieldDesc("data", 3, 8),
                 FieldDesc("dims", 4, 0),
             ]
@@ -1696,8 +1715,8 @@ end
     end
 
     @testset "CMatrix vocabulary" begin
-        # CMatrix{T} = CArray{T,2}: recognition + column-major numpy helpers
-        # in the Python emitter.
+        # CMatrix{owned,T} = CArray{owned,T,2}: recognition + column-major numpy
+        # helpers in the Python emitter.
         abi = read_abi_info("bindinginfo_cmatrix.json")
         mktempdir() do path
             dest = PythonTarget(path, "cmatrix_demo", "libcmatrix")
@@ -1711,11 +1730,15 @@ end
             pyproject = read(joinpath(path, "pyproject.toml"), String)
             @test occursin("dependencies = [\"numpy>=1.20\"]", pyproject)
 
-            # The struct class is emitted with the new `dims` array field and
-            # decorated with helpers.
-            @test occursin("class CMatrix_Float64(ctypes.Structure):", bindings)
+            # The struct class is emitted with the two-field layout and
+            # decorated with the borrowed-flavored helpers.
+            @test occursin("class CMatrix_borrowed_Float64(ctypes.Structure):", bindings)
             @test occursin("(\"dims\", (ctypes.c_int32 * 2))", bindings)
             @test occursin("(\"data\", ctypes.POINTER(ctypes.c_double))", bindings)
+            # Borrowed storage belongs to the caller: no ownership field, and
+            # no `free()` to call on memory this side never allocated.
+            @test !occursin("owned", bindings)
+            @test !occursin("def free(self):", bindings)
 
             # from_numpy enforces column-major (Fortran) layout — silently
             # treating a C-order numpy array as column-major would transpose.
@@ -1740,7 +1763,7 @@ end
             facade = read(joinpath(path, "cmatrix_demo", "_facade.py"), String)
             @test occursin("import numpy as np", facade)
             @test occursin(
-                "def trace_cmatrix(m):\n    _m = CMatrix_Float64.from_numpy(m)\n" *
+                "def trace_cmatrix(m):\n    _m = CMatrix_borrowed_Float64.from_numpy(m)\n" *
                     "    return _lowlevel.trace_cmatrix(_m)", facade
             )
             golden_facade = read(joinpath(@__DIR__, "expected_cmatrix_facade.py"), String)
@@ -1758,8 +1781,8 @@ end
 
     @testset "CArray{T,3} vocabulary" begin
         # Locks in 3-D coverage: the rank-agnostic CArray recognizer should
-        # accept `CArray{Float64,3}` and the emitter should produce the same
-        # helper shape as for N=1,2 but with ndim=3 dispatches.
+        # accept `CArray{:borrowed, Float64, 3}` and the emitter should produce
+        # the same helper shape as for N=1,2 but with ndim=3 dispatches.
         abi = read_abi_info("bindinginfo_carray3.json")
         mktempdir() do path
             dest = PythonTarget(path, "carray3_demo", "libcarray3")
@@ -1768,8 +1791,10 @@ end
             bindings_path = joinpath(path, "carray3_demo", "_lowlevel.py")
             bindings = read(bindings_path, String)
 
-            @test occursin("class CArray_Float64_3(ctypes.Structure):", bindings)
+            @test occursin("class CArray_borrowed_Float64_3(ctypes.Structure):", bindings)
             @test occursin("(\"dims\", (ctypes.c_int32 * 3))", bindings)
+            @test !occursin("owned", bindings)
+            @test !occursin("def free(self):", bindings)
             @test occursin("if arr.ndim != 3:", bindings)
             @test occursin("if not arr.flags.f_contiguous:", bindings)
             @test occursin("dims=(ctypes.c_int32 * 3)(*arr.shape)", bindings)
@@ -1783,7 +1808,7 @@ end
 
             facade = read(joinpath(path, "carray3_demo", "_facade.py"), String)
             @test occursin(
-                "def sum3d(a):\n    _a = CArray_Float64_3.from_numpy(a)\n" *
+                "def sum3d(a):\n    _a = CArray_borrowed_Float64_3.from_numpy(a)\n" *
                     "    return _lowlevel.sum3d(_a)", facade
             )
             golden_facade = read(joinpath(@__DIR__, "expected_carray3_facade.py"), String)
@@ -1800,11 +1825,11 @@ end
     end
 
     @testset "CArray owned-return vocabulary" begin
-        # Exercises the owning-return (`owned == 1`) façade path for CArray:
-        # carray3/cmatrix/libsimple only ever cover borrowed CArray arguments,
-        # so this dedicated fixture (one no-arg function returning a fresh
-        # CVector{Float64}, plus the macro-emitted release entrypoints) is
-        # what actually drives `:carray_unwrap` through `write_wrapper`.
+        # Exercises the owning-return façade path for CArray: carray3/cmatrix/
+        # libsimple only ever cover borrowed CArrays, so this dedicated fixture
+        # (one no-arg function returning a fresh CVector{:owned, Float64}, plus
+        # the macro-emitted release entrypoints) is what actually drives
+        # `:carray_unwrap` through `write_wrapper`.
         abi = read_abi_info("bindinginfo_carray_owned.json")
         mktempdir() do path
             dest = PythonTarget(path, "carray_owned_demo", "libcarrayowned")
@@ -1813,26 +1838,29 @@ end
             bindings_path = joinpath(path, "carray_owned_demo", "_lowlevel.py")
             bindings = read(bindings_path, String)
 
-            # `.free()` is a genuine no-op at owned=0, regardless of
-            # release_present — the shared `_emit_free_method` shape.
-            @test occursin("(\"owned\", ctypes.c_int32)", bindings)
-            @test occursin("owned=0)", bindings)  # from_numpy always borrows
-            @test occursin("        if self.owned != 1:\n            return", bindings)
+            # An owning class has no `from_numpy`: Python has no Julia
+            # allocation to hand over. It does get `free()`, made idempotent by
+            # a Python-side attribute since the struct carries no flag.
+            @test occursin("class CVector_owned_Float64(ctypes.Structure):", bindings)
+            @test !occursin("def from_numpy(cls, arr):", bindings)
+            @test !occursin("owned=0", bindings)
+            @test occursin("        if getattr(self, \"_freed\", False):\n            return", bindings)
             @test occursin("_lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))", bindings)
+            @test occursin("        self._freed = True", bindings)
 
             golden = read(joinpath(@__DIR__, "expected_carray_owned_lowlevel.py"), String)
             @test bindings == golden
 
-            # Façade auto-wrap: copy-then-free via try/finally + .free().
+            # Façade auto-wrap: copy unconditionally, then free in `finally`.
             facade = read(joinpath(path, "carray_owned_demo", "_facade.py"), String)
             @test occursin(
                 "def give_vec():\n    _result = _lowlevel.give_vec()\n" *
-                    "    try:\n        if _result.owned == 1:\n" *
-                    "            _out = np.array(_result.as_numpy(), copy=True)\n" *
-                    "        else:\n            _out = _result.as_numpy()\n" *
+                    "    try:\n        _out = np.array(_result.as_numpy(), copy=True)\n" *
                     "    finally:\n        _result.free()\n    return _out",
                 facade
             )
+            # No runtime ownership test survives: the type already decided.
+            @test !occursin("_result.owned", facade)
             # No manual free call bypassing `.free()`, and no `ctypes` import
             # (the façade no longer touches `ctypes.*` directly).
             @test !occursin("_lowlevel._lib.jlw_free", facade)
@@ -1849,6 +1877,120 @@ end
                 error("python3 not found on PATH; required on CI to validate the emitted wrapper")
             end
         end
+    end
+
+    @testset "CArray owning return without release symbols" begin
+        # A library that returns an owning CArray but has not exported the
+        # release entrypoints must not have that return auto-wrapped — the
+        # façade would emit a call to a symbol the shared library does not
+        # export. Same gate as CStrArray/CDict: give_vec falls back to a
+        # mechanical TODO naming the macro to add.
+        abi = read_abi_info("bindinginfo_carray_owned_nofree.json")
+        @test JuliaLibWrapping._release_symbols_present(abi) === false
+        mktempdir() do path
+            dest = PythonTarget(path, "carray_owned_nofree_demo", "libcarrayownednofree")
+            write_wrapper(dest, abi)
+
+            bindings_path = joinpath(path, "carray_owned_nofree_demo", "_lowlevel.py")
+            bindings = read(bindings_path, String)
+            # Nothing is bound on `_lib` for the absent entrypoints, so
+            # `.free()` — kept so the class API shape does not depend on the
+            # library — reports the missing macro instead of raising a bare
+            # `AttributeError` on `_lib.jlw_free`.
+            @test !occursin("_lib.jlw_free.argtypes", bindings)
+            @test !occursin("_lib.jlw_free.restype", bindings)
+            @test occursin("def free(self):", bindings)
+            @test !occursin("_lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))", bindings)
+            @test occursin(
+                "raise RuntimeError(\"this library does not export release entrypoints; " *
+                    "add JLWInterop.@export_release_entrypoints to the library\")",
+                bindings
+            )
+
+            golden = read(joinpath(@__DIR__, "expected_carray_owned_nofree_lowlevel.py"), String)
+            @test bindings == golden
+
+            facade = read(joinpath(path, "carray_owned_nofree_demo", "_facade.py"), String)
+            @test !occursin("def give_vec():", facade)
+            @test occursin(
+                "from ._lowlevel import give_vec  # TODO: hand-wrap — " *
+                    "owning return needs release entrypoints; add " *
+                    "JLWInterop.@export_release_entrypoints to the library",
+                facade
+            )
+            golden_facade = read(joinpath(@__DIR__, "expected_carray_owned_nofree_facade.py"), String)
+            @test facade == golden_facade
+
+            python3 = Sys.which("python3")
+            if !isnothing(python3)
+                cmd = `$python3 -c "import ast; ast.parse(open('$bindings_path').read())"`
+                @test success(run(pipeline(cmd; stderr = devnull, stdout = devnull); wait = true))
+                facade_path = joinpath(path, "carray_owned_nofree_demo", "_facade.py")
+                cmd_f = `$python3 -c "import ast; ast.parse(open('$facade_path').read())"`
+                @test success(run(pipeline(cmd_f; stderr = devnull, stdout = devnull); wait = true))
+            elseif haskey(ENV, "CI")
+                error("python3 not found on PATH; required on CI to validate the emitted wrapper")
+            end
+        end
+    end
+
+    @testset "CArray façade classification by ownership" begin
+        # Ownership is read off the type name, and it decides the shape of the
+        # wrapper on both sides of the call.
+        classify_arg = JuliaLibWrapping._facade_classify_arg
+        classify_ret = JuliaLibWrapping._facade_classify_return
+        findtype(descs, name) = (
+            k = collect(keys(descs));
+            k[findfirst((id) -> descs[id].name === name, k)]
+        )
+        premangled(abi) = (
+            d = Dict{Int, String}();
+            for (id, type) in pairs(abi.typeinfo)
+                type isa StructDesc && JuliaLibWrapping.mangle_python!(d, id, abi.typeinfo)
+            end;
+            d
+        )
+
+        borrowed = read_abi_info("bindinginfo_cmatrix.json")
+        td_b = premangled(borrowed)
+        cm_id = findtype(borrowed.typeinfo, "CMatrix{:borrowed, Float64}")
+
+        # A borrowed argument arrives from numpy.
+        arg_b = JuliaLibWrapping.ArgDesc("m", cm_id, false)
+        @test classify_arg(arg_b, borrowed.typeinfo, td_b).kind === :carray
+
+        # A borrowed return is a zero-copy view, and needs no release
+        # entrypoints because it releases nothing.
+        ret_b = JuliaLibWrapping.MethodDesc(
+            "view_cmatrix", "view_cmatrix()", cm_id, JuliaLibWrapping.ArgDesc[]
+        )
+        plan_b = JuliaLibWrapping._facade_plan(ret_b, borrowed.typeinfo, td_b, false)
+        @test plan_b.category === :auto
+        @test plan_b.ret.kind === :carray_view
+        # The emitted wrapper hands the view straight back: no copy, no
+        # try/finally, no free.
+        @test sprint(JuliaLibWrapping._emit_facade_autowrapper, ret_b, plan_b) ==
+            "def view_cmatrix():\n    _result = _lowlevel.view_cmatrix()\n" *
+            "    return _result.as_numpy()\n\n"
+
+        owned = read_abi_info("bindinginfo_carray_owned.json")
+        td_o = premangled(owned)
+        cv_id = findtype(owned.typeinfo, "CVector{:owned, Float64}")
+        m_owned = onlymatch(md -> md.symbol == "give_vec", owned.entrypoints)
+
+        # An owning return is copied then freed, and only when the library
+        # exports the release entrypoints.
+        @test classify_ret(m_owned, owned.typeinfo, td_o, true).kind === :carray_unwrap
+        demoted = classify_ret(m_owned, owned.typeinfo, td_o, false)
+        @test demoted.kind === :opaque
+        @test occursin("owning return needs release entrypoints", demoted.reason)
+
+        # An owning CArray argument transfers a Julia allocation into the
+        # library; numpy cannot supply one, so the wrapper is left to a human.
+        arg_o = JuliaLibWrapping.ArgDesc("a", cv_id, false)
+        cls = classify_arg(arg_o, owned.typeinfo, td_o)
+        @test cls.kind === :opaque
+        @test cls.reason == "argument transfers CArray ownership into the library; hand-wrap"
     end
 
     @testset "raw primitive pointer docstring" begin
@@ -1880,7 +2022,7 @@ end
             )
             @test occursin("`data` is a raw pointer to Float64", bindings)
             @test occursin("column-major (Fortran order)", bindings)
-            @test occursin("`CArray{T,N}`", bindings)
+            @test occursin("`CArray{owned,T,N}`", bindings)
 
             golden = read(joinpath(@__DIR__, "expected_rawptr_lowlevel.py"), String)
             @test bindings == golden


### PR DESCRIPTION
CArray becomes CArray{owned,T,N}: the leading parameter is :owned or :borrowed, the runtime `owned` field is gone, and the layout is back to (dims, data). The inner constructor is the only route to `new` and rejects any other ownership symbol, so every construction path states an ownership explicitly. CArray{:owned}(A::AbstractArray) allocates the malloc'd dense column-major copy (tested for OffsetArray and non-contiguous view inputs); CArray{:borrowed}(::AbstractArray) throws, since borrowed carriers wrap caller-managed memory reached through a pointer.