### PR TITLE
Encode CString ownership in its type

### DIFF
--- a/JLWInterop/src/JLWInterop.jl
+++ b/JLWInterop/src/JLWInterop.jl
@@ -186,44 +186,71 @@ Base.@propagate_inbounds function Base.setindex!(a::CArray{owned, T}, x, i::Int)
 end
 
 """
-    CString
+    CString{owned}
 
-Non-owning UTF-8 string descriptor for `@ccallable` boundaries. It contains
-`length` bytes at `data`; embedded NUL bytes are allowed.
-The caller must keep the buffer alive while the descriptor is in use.
+Length-prefixed UTF-8 string descriptor for `@ccallable` boundaries.
+It contains `length` bytes at `data` and permits embedded NUL bytes.
+
+# Ownership contract
+
+`owned` is `:owned` or `:borrowed`.
+
+`CString{:owned}(::AbstractString)` allocates a copy. The consumer releases
+`data` once with `Libc.free` or the `jlw_free` entrypoint emitted by
+[`@export_release_entrypoints`](@ref).
+
+`CString{:borrowed}` wraps a buffer the caller owns and keeps alive; the
+consumer never releases it.
 
 # Example
 
 ```julia
 using JLWInterop
 
-Base.@ccallable function greeting_length(s::CString)::Int32
+Base.@ccallable function greeting_length(s::CString{:borrowed})::Int32
     return Int32(length(s))
 end
+
+s = CString{:owned}("héllo")
+String(s) == "héllo"
+Libc.free(s.data)
 ```
 
 # Extended help
 
 Unlike `Base.Cstring`, `CString` is length-prefixed rather than NUL-terminated.
-It does not allocate, copy, free, or keep its storage alive.
 
-Use it to expose a string value at a `@ccallable` boundary instead of a
-`String` (which is not C-ABI compatible) or a `Cstring` (which requires
-NUL termination and forbids embedded NULs). Binding targets can map its
-name and layout to native string and byte-sequence types.
+Use it instead of a `String`, which is not C-ABI compatible, or a `Cstring`,
+which requires NUL termination and forbids embedded NULs.
 
-`CString <: AbstractString` with `ncodeunits`, `codeunit`, and a fast
-byte-level `cmp`; Base derives UTF-8 iteration, `length` (character
-count vs. `ncodeunits` byte count), equality, `print`, regex matching,
-`split`, `replace`, and the rest of the `AbstractString` interface. Use
-`String(s)` to copy the bytes out into a fresh heap-allocated Julia
-`String` when you need ownership.
+Every construction path names an ownership: there is no defaulting
+constructor, and any parameter other than `:owned` or `:borrowed` is
+rejected.
 
-The caller must keep `s.data` valid for the duration of the call.
+`CString{owned} <: AbstractString`. Use `String(s)` to copy its bytes into a
+Julia `String`.
 """
-struct CString <: AbstractString
+struct CString{owned} <: AbstractString
     length::Int32
     data::Ptr{UInt8}
+
+    function CString{owned}(length, data) where {owned}
+        owned === :owned || owned === :borrowed || throw(
+            ArgumentError(
+                "ownership parameter must be :owned or :borrowed, got $(repr(owned))"
+            )
+        )
+        return new{owned}(length, data)
+    end
+end
+
+# Allocate a copy of `s`'s UTF-8 bytes, without a terminating NUL.
+function CString{:owned}(s::AbstractString)
+    str = String(s)
+    nb = sizeof(str)
+    p = Ptr{UInt8}(Libc.malloc(max(nb, 1)))  # never malloc(0): an empty string still needs a non-NULL, freeable p
+    GC.@preserve str unsafe_copyto!(p, pointer(str), nb)
+    return CString{:owned}(Int32(nb), p)
 end
 
 Base.ncodeunits(s::CString) = Int(s.length)
@@ -333,6 +360,9 @@ with `_free_strings` or the `jlw_free_strings` entrypoint emitted by
 consumer never releases it. Converting to `Vector{String}` copies without
 freeing the source.
 
+Elements share the container's ownership — `data` points to `CString{owned}`s
+— and releasing an owning `CStrArray` releases every element's buffer too.
+
 There is no default ownership or constructor that borrows a `Vector{String}`;
 borrowed carriers arrive across the ABI.
 
@@ -348,7 +378,7 @@ JLWInterop._free_strings(a.data, a.length)
 """
 struct CStrArray{owned}
     length::Int64
-    data::Ptr{CString}     # each element a length-prefixed CString
+    data::Ptr{CString{owned}}     # each element a length-prefixed CString
 
     function CStrArray{owned}(length, data) where {owned}
         owned === :owned || owned === :borrowed || throw(
@@ -372,26 +402,22 @@ end
 # Allocate a copy of `v` as length-prefixed CStrings.
 function CStrArray{:owned}(v::Vector{String})
     n = length(v)
-    data = Ptr{CString}(Libc.malloc(max(n, 1) * sizeof(CString)))
+    data = Ptr{CString{:owned}}(Libc.malloc(max(n, 1) * sizeof(CString{:owned})))
     for i in 1:n
-        s = v[i]
-        nb = sizeof(s)
-        p = Ptr{UInt8}(Libc.malloc(max(nb, 1)))  # never malloc(0): an empty string still needs a non-NULL, freeable p
-        GC.@preserve s unsafe_copyto!(p, pointer(s), nb)
-        unsafe_store!(data, CString(Int32(nb), p), i)
+        unsafe_store!(data, CString{:owned}(v[i]), i)
     end
     return CStrArray{:owned}(Int64(n), data)
 end
 
 """
-    JLWInterop._free_strings(p::Ptr{CString}, n::Int64)
+    JLWInterop._free_strings(p::Ptr{CString{:owned}}, n::Int64)
 
 Free `n` string buffers pointed to by the `CString`s at `p` (each one's
 `.data`), then free `p` itself. Matches the allocation made by
 `CStrArray{:owned}(::Vector{String})`. Internal; exposed at a `@ccallable`
 boundary as `jlw_free_strings` by [`@export_release_entrypoints`](@ref).
 """
-function _free_strings(p::Ptr{CString}, n::Int64)
+function _free_strings(p::Ptr{CString{:owned}}, n::Int64)
     for i in 1:n
         Libc.free(unsafe_load(p, i).data)
     end
@@ -430,6 +456,9 @@ property of its type.
 `CDict{:borrowed,V}` wraps memory the caller owns and keeps alive; the consumer
 never releases it. Converting to a `Dict` copies without freeing the source.
 
+Keys share the dictionary's ownership — `keys` points to `CString{owned}`s —
+and releasing them releases every key's buffer too.
+
 There is no default ownership or constructor that borrows a `Dict`; borrowed
 carriers arrive across the ABI.
 
@@ -446,7 +475,7 @@ Libc.free(c.values)
 """
 struct CDict{owned, V}
     length::Int64
-    keys::Ptr{CString}
+    keys::Ptr{CString{owned}}
     values::Ptr{V}
 
     function CDict{owned, V}(length, keys, values) where {owned, V}
@@ -476,15 +505,12 @@ for V in CDICT_VALUE_TYPES
         end
         function CDict{:owned}(dict::Dict{String, $V})
             n = length(dict)
-            kp = Ptr{CString}(Libc.malloc(max(n, 1) * sizeof(CString)))
+            kp = Ptr{CString{:owned}}(Libc.malloc(max(n, 1) * sizeof(CString{:owned})))
             vp = Ptr{$V}(Libc.malloc(max(n, 1) * sizeof($V)))
             i = 0
             for (k, v) in dict
                 i += 1
-                nb = sizeof(k)
-                p = Ptr{UInt8}(Libc.malloc(max(nb, 1)))  # never malloc(0): an empty key still needs a non-NULL, freeable p
-                GC.@preserve k unsafe_copyto!(p, pointer(k), nb)
-                unsafe_store!(kp, CString(Int32(nb), p), i)
+                unsafe_store!(kp, CString{:owned}(k), i)
                 unsafe_store!(vp, v, i)
             end
             return CDict{:owned, $V}(Int64(n), kp, vp)
@@ -538,7 +564,7 @@ macro export_release_entrypoints()
                 Libc.free(p)
                 return nothing
             end
-            Base.@ccallable function jlw_free_strings(p::Ptr{CString}, n::Int64)::Cvoid
+            Base.@ccallable function jlw_free_strings(p::Ptr{CString{:owned}}, n::Int64)::Cvoid
                 JLWInterop._free_strings(p, n)
                 return nothing
             end

--- a/JLWInterop/test/runtests.jl
+++ b/JLWInterop/test/runtests.jl
@@ -86,19 +86,63 @@ using Test
     end
 
     @testset "CString layout" begin
-        @test fieldnames(CString) == (:length, :data)
-        @test fieldtype(CString, :length) === Int32
-        @test fieldtype(CString, :data) === Ptr{UInt8}
-        @test isbitstype(CString)
-        @test fieldoffset(CString, 1) == 0
-        @test fieldoffset(CString, 2) == 8
-        @test CString <: AbstractString
+        @test fieldnames(CString{:borrowed}) == (:length, :data)
+        @test fieldtype(CString{:borrowed}, :length) === Int32
+        @test fieldtype(CString{:borrowed}, :data) === Ptr{UInt8}
+        @test isbitstype(CString{:borrowed})
+        @test fieldoffset(CString{:borrowed}, 1) == 0
+        @test fieldoffset(CString{:borrowed}, 2) == 8
+        @test CString{:borrowed} <: AbstractString
+
+        # Ownership is part of the type, so the two flavors are distinct types
+        # with identical layout.
+        @test CString{:owned} !== CString{:borrowed}
+        @test sizeof(CString{:owned}) == sizeof(CString{:borrowed}) == 16
+    end
+
+    @testset "CString ABI names" begin
+        # `juliac` writes the ABI JSON's struct names with
+        # `repr(dt; context = :compact => true)`, and JuliaLibWrapping's
+        # recognizer parses the ownership back out of that text.
+        compact(T) = repr(T; context = :compact => true)
+        @test compact(CString{:owned}) == "CString{:owned}"
+        @test compact(CString{:borrowed}) == "CString{:borrowed}"
+    end
+
+    @testset "CString constructors" begin
+        # There is no ownership-defaulting constructor.
+        @test_throws MethodError CString(Int32(0), Ptr{UInt8}(0))
+        @test_throws MethodError CString("hello")
+
+        # Only :owned and :borrowed name an ownership.
+        @test_throws(
+            "ownership parameter must be :owned or :borrowed, got :mine",
+            CString{:mine}(Int32(0), Ptr{UInt8}(0))
+        )
+        @test_throws(
+            "ownership parameter must be :owned or :borrowed, got 1",
+            CString{1}(Int32(0), Ptr{UInt8}(0))
+        )
+    end
+
+    @testset "CString owning round-trip" begin
+        s = CString{:owned}("hé\0llo")   # incl. multi-byte UTF-8 and an embedded NUL
+        @test s isa CString{:owned}
+        @test s.length == 7
+        @test String(s) == "hé\0llo"
+        Libc.free(s.data)                       # tests own the free
+
+        empty = CString{:owned}("")
+        @test empty.length == 0
+        @test empty.data != C_NULL   # empty string still mallocs a real, freeable pointer
+        @test String(empty) == ""
+        Libc.free(empty.data)
     end
 
     @testset "CString AbstractString interface" begin
         buf = codeunits("hello")
         GC.@preserve buf begin
-            s = CString(Int32(length(buf)), pointer(buf))
+            s = CString{:borrowed}(Int32(length(buf)), pointer(buf))
 
             # AbstractString-derived methods.
             @test ncodeunits(s) === 5
@@ -120,7 +164,7 @@ using Test
         # Embedded NUL bytes are preserved (length-prefixed, not terminated).
         raw = UInt8[0x66, 0x00, 0x6f]  # "f\0o"
         GC.@preserve raw begin
-            s = CString(Int32(length(raw)), pointer(raw))
+            s = CString{:borrowed}(Int32(length(raw)), pointer(raw))
             @test ncodeunits(s) === 3
             @test codeunit(s, 2) === 0x00
             @test String(s) == "f\0o"
@@ -129,7 +173,7 @@ using Test
         # Multi-byte UTF-8 ("café"): 4 characters, 5 bytes.
         utf8 = codeunits("café")
         GC.@preserve utf8 begin
-            s = CString(Int32(length(utf8)), pointer(utf8))
+            s = CString{:borrowed}(Int32(length(utf8)), pointer(utf8))
             @test ncodeunits(s) === 5
             @test length(s) === 4
             @test collect(s) == ['c', 'a', 'f', 'é']
@@ -141,8 +185,8 @@ using Test
         a_buf = codeunits("apple")
         b_buf = codeunits("banana")
         GC.@preserve a_buf b_buf begin
-            a = CString(Int32(length(a_buf)), pointer(a_buf))
-            b = CString(Int32(length(b_buf)), pointer(b_buf))
+            a = CString{:borrowed}(Int32(length(a_buf)), pointer(a_buf))
+            b = CString{:borrowed}(Int32(length(b_buf)), pointer(b_buf))
             @test cmp(a, b) < 0
             @test cmp(b, a) > 0
             @test cmp(a, a) == 0
@@ -416,7 +460,7 @@ using Test
     @testset "CStrArray layout" begin
         @test fieldnames(CStrArray{:owned}) === (:length, :data)
         @test fieldtype(CStrArray{:owned}, :length) === Int64
-        @test fieldtype(CStrArray{:owned}, :data) === Ptr{CString}
+        @test fieldtype(CStrArray{:owned}, :data) === Ptr{CString{:owned}}
         @test isbitstype(CStrArray{:owned})
         @test iszero(fieldoffset(CStrArray{:owned}, 1))
         @test fieldoffset(CStrArray{:owned}, 2) == 8
@@ -438,7 +482,7 @@ using Test
     end
 
     @testset "CStrArray constructors" begin
-        a = CStrArray{:borrowed}(Int64(0), Ptr{CString}(0))
+        a = CStrArray{:borrowed}(Int64(0), Ptr{CString{:borrowed}}(0))
         @test a isa CStrArray{:borrowed}
         @test a.length === Int64(0)
 
@@ -450,11 +494,11 @@ using Test
         # Only :owned and :borrowed name an ownership.
         @test_throws(
             "ownership parameter must be :owned or :borrowed, got :mine",
-            CStrArray{:mine}(Int64(0), Ptr{CString}(0))
+            CStrArray{:mine}(Int64(0), Ptr{CString{:owned}}(0))
         )
         @test_throws(
             "ownership parameter must be :owned or :borrowed, got 1",
-            CStrArray{1}(Int64(0), Ptr{CString}(0))
+            CStrArray{1}(Int64(0), Ptr{CString{:owned}}(0))
         )
     end
 
@@ -478,7 +522,7 @@ using Test
     @testset "CDict layout" begin
         @test fieldnames(CDict{:owned, Float64}) === (:length, :keys, :values)
         @test fieldtype(CDict{:owned, Float64}, :length) === Int64
-        @test fieldtype(CDict{:owned, Float64}, :keys) === Ptr{CString}
+        @test fieldtype(CDict{:owned, Float64}, :keys) === Ptr{CString{:owned}}
         @test fieldtype(CDict{:owned, Float64}, :values) === Ptr{Float64}
         @test isbitstype(CDict{:owned, Float64})
         @test iszero(fieldoffset(CDict{:owned, Float64}, 1))
@@ -498,7 +542,7 @@ using Test
 
     @testset "CDict constructors" begin
         # `V` is inferred from the value pointer.
-        c = CDict{:borrowed}(Int64(0), Ptr{CString}(0), Ptr{Float64}(0))
+        c = CDict{:borrowed}(Int64(0), Ptr{CString{:borrowed}}(0), Ptr{Float64}(0))
         @test c isa CDict{:borrowed, Float64}
 
         # There is no ownership-defaulting constructor, and no Julia-side
@@ -508,11 +552,11 @@ using Test
 
         @test_throws(
             "ownership parameter must be :owned or :borrowed, got :mine",
-            CDict{:mine, Float64}(Int64(0), Ptr{CString}(0), Ptr{Float64}(0))
+            CDict{:mine, Float64}(Int64(0), Ptr{CString{:owned}}(0), Ptr{Float64}(0))
         )
         @test_throws(
             "ownership parameter must be :owned or :borrowed, got 1",
-            CDict{1, Float64}(Int64(0), Ptr{CString}(0), Ptr{Float64}(0))
+            CDict{1, Float64}(Int64(0), Ptr{CString{:owned}}(0), Ptr{Float64}(0))
         )
     end
 

--- a/JuliaLibWrapping/docs/src/concepts.md
+++ b/JuliaLibWrapping/docs/src/concepts.md
@@ -112,9 +112,9 @@ package directory:
   regenerated** on every `write_wrapper` call.
 - `_facade.py` — the package's public API. JuliaLibWrapping creates this
   file only if it does not exist. Its initial version wraps entrypoints whose
-  arguments and return are recognized —
-  primitive scalars, `CVector{owned,T}`, `CMatrix{owned,T}`, `CString`, or a
-  direct `JLWStatus` return — is auto-wrapped to accept and return
+  arguments and return are recognized — primitive scalars,
+  `CVector{owned,T}`, `CMatrix{owned,T}`, `CString{owned}`, or a direct
+  `JLWStatus` return — is auto-wrapped to accept and return
   idiomatic Python objects (numpy arrays, `str`). Entrypoints with a
   raw pointer, an unrecognized struct, or an embedded `JLWStatus`
   field are re-exported with a `# TODO: hand-wrap` comment. Delete the file and
@@ -124,7 +124,8 @@ package directory:
 Users normally import the package-level API from `_facade`. The generated
 bindings remain available under `pkg._lowlevel` when direct access is needed.
 
-Recognition of `CArray`, `CString`, and `JLWStatus` is structural. Use
+Recognition of `CArray`, `CString`, and `JLWStatus` matches the type name,
+ownership parameter (where present), and field layout. Use
 [JLWInterop](https://github.com/JuliaInterop/JuliaLibWrapping.jl/tree/main/JLWInterop)
 for their canonical definitions.
 

--- a/JuliaLibWrapping/docs/src/jlwinterop.md
+++ b/JuliaLibWrapping/docs/src/jlwinterop.md
@@ -12,12 +12,11 @@ JLWInterop
 
 The package defines fixed-layout types for passing values across a C ABI.
 Borrowed values do not own their underlying storage; the caller must keep the
-storage alive for the duration of the call. `CArray`, `CStrArray`, and `CDict`
-each state their ownership in a leading `:owned`/`:borrowed` type parameter,
-so whether a value must be released is visible in its type. The types are
-`isbits` when their element types are, work
-with `juliac --trim`, and cross a `@ccallable` boundary without allocating a
-Julia object.
+storage alive for the duration of the call. `CArray`, `CString`, `CStrArray`,
+and `CDict` each state their ownership in a leading `:owned`/`:borrowed` type
+parameter. The types are `isbits` when their element types are, work with
+`juliac --trim`, and cross a `@ccallable` boundary without allocating a Julia
+object.
 
 JuliaLibWrapping targets recognize these types structurally, by name and field
 layout. Using `JLWInterop` keeps those layouts consistent across libraries.
@@ -102,10 +101,10 @@ gets `from_numpy` and `as_numpy` and no `free()`; an owning class gets
 
 A library returning an owning `CArray` without
 [`@export_release_entrypoints`](@ref) is demoted at build time to a `TODO`
-re-export naming the macro to add — the same rule as `CStrArray` and `CDict`.
-An owning `CArray` *argument* is likewise left to a human: it would transfer a
-Julia allocation into the library, which numpy cannot supply. The same holds
-for owning `CStrArray` and `CDict` arguments.
+re-export naming the macro to add — the same rule as `CString`, `CStrArray`,
+and `CDict`. An owning `CArray` *argument* is likewise left to a human: it
+would transfer a Julia allocation into the library, which numpy cannot supply.
+The same holds for owning `CString`, `CStrArray`, and `CDict` arguments.
 
 For `N ≥ 2`, the generated `from_numpy` helper requires a Fortran-contiguous
 array. Convert row-major input with `np.asfortranarray`.
@@ -122,17 +121,33 @@ CVector
 CMatrix
 ```
 
-## `CString` — length-prefixed UTF-8
+## `CString{owned}` — length-prefixed UTF-8
 
-`CString` is `(length::Int32, data::Ptr{UInt8})`. It is length-prefixed, so it
-permits embedded NUL bytes.
+`CString{owned}` is `(length::Int32, data::Ptr{UInt8})`. It is length-prefixed,
+so it permits embedded NUL bytes.
 
-As with the other types, `CString` borrows storage from the caller.
-The Python target generates
-`from_str` / `as_str` (UTF-8 round-trip) plus `from_bytes` /
-`as_bytes` (raw bytes) helpers.
+`CString{owned} <: AbstractString`; call `String(s)` to copy the bytes into a
+Julia `String`.
 
-`CString <: AbstractString`; call `String(s)` to make an owning copy.
+### `CString` ownership contract
+
+`owned` is `:owned` or `:borrowed`; both types have the same layout.
+
+- `CString{:borrowed}` wraps a buffer the caller owns and keeps alive; the
+  consumer never releases it.
+- `CString{:owned}(::AbstractString)` allocates a copy of the UTF-8 bytes. The
+  consumer releases `data` once with `jlw_free`.
+
+### Python target
+
+| Julia | Python |
+|---|---|
+| `AbstractString` | `str` |
+
+A borrowed class gets `from_str`, `from_bytes`, `as_str`, and `as_bytes`. An
+owning class gets the conversion methods and an idempotent `free()`, but no
+constructors. Owning returns are decoded and freed in a `finally`; owning
+arguments require a manual wrapper.
 
 ```@docs
 CString
@@ -140,9 +155,9 @@ CString
 
 ## `CStrArray{owned}` — string arrays
 
-`CStrArray{owned}` is `(length::Int64, data::Ptr{CString})`: a pointer to
-`length` [`CString`](@ref)s. Converting it to `Vector{String}` copies the
-strings without freeing the source.
+`CStrArray{owned}` is `(length::Int64, data::Ptr{CString{owned}})`: a pointer
+to `length` [`CString`](@ref)s with matching ownership. Converting it to
+`Vector{String}` copies the strings without freeing the source.
 
 Each string uses an `Int32` byte length; oversized strings throw
 `InexactError` rather than being truncated.
@@ -174,8 +189,9 @@ CStrArray
 
 ## `CDict{owned,V}` — string-keyed dictionaries
 
-`CDict{owned,V}` is `(length::Int64, keys::Ptr{CString}, values::Ptr{V})`: two
-parallel arrays. Keys are [`CString`](@ref)s; values use a type in
+`CDict{owned,V}` is `(length::Int64, keys::Ptr{CString{owned}},
+values::Ptr{V})`: two parallel arrays. Keys are [`CString`](@ref)s with
+matching ownership; values use a type in
 [`CDICT_VALUE_TYPES`](@ref). Converting to a Julia `Dict` copies without
 freeing the source.
 
@@ -227,8 +243,8 @@ unwrap
 
 ## Owning carrier returns
 
-Libraries returning an owning `CArray`, `CStrArray`, or `CDict` must emit the
-release entrypoints at module top level:
+Libraries returning an owning `CArray`, `CString`, `CStrArray`, or `CDict`
+must emit the release entrypoints at module top level:
 
 ```julia
 using JLWInterop

--- a/JuliaLibWrapping/docs/src/tutorial.md
+++ b/JuliaLibWrapping/docs/src/tutorial.md
@@ -16,7 +16,7 @@ types:
 | `CMatrix{:borrowed,Float64}` | design matrix `X`                  |
 | `CVector{:borrowed,Float64}` | response `y`, coefficients, predictions |
 | `Float64` (primitive)      | `r_squared`                          |
-| `CString`                  | output buffer for `summary_report`   |
+| `CString{:borrowed}`       | output buffer for `summary_report`   |
 | `JLWStatus` (direct)       | return of `predict`                  |
 | `JLWStatus` (embedded)     | `FitResult.status` field             |
 
@@ -54,14 +54,14 @@ Base.@ccallable function predict(coeffs::CVector{:borrowed, Float64},
                                   out::CVector{:borrowed, Float64})::JLWStatus
 
 Base.@ccallable function summary_report(result::FitResult,
-                                         buf::CString)::JLWStatus
+                                         buf::CString{:borrowed})::JLWStatus
 ```
 
 See `examples/ols/src/ols.jl` for the complete implementation.
 
 `coeffs_buf` and `out` are *caller-allocated* buffers: the library writes into
 them but does not own them, which is what the `:borrowed` parameter records.
-`CString` borrows likewise.
+`summary_report`'s `CString{:borrowed}` buffer works the same way.
 
 Errors travel back as a `JLWStatus`,
 either returned directly (`predict`, `summary_report`) or embedded in
@@ -267,13 +267,14 @@ method; this returns the pieces directly to keep the example short.
 
 `summary_report` is also a hand-wrap case (its `FitResult` argument
 is an unrecognized struct). The caller allocates a writable
-`CString` buffer, passes it in, and decodes the bytes after the call:
+`CString{:borrowed}` buffer, passes it in, and decodes the bytes after the
+call:
 
 ```python
 def summary_report(result_struct, capacity=256):
     import ctypes
     buf_bytes = (ctypes.c_uint8 * capacity)()
-    buf = _lowlevel.CString(
+    buf = _lowlevel.CString_borrowed(
         length=capacity,
         data=ctypes.cast(buf_bytes, ctypes.POINTER(ctypes.c_uint8)),
     )

--- a/JuliaLibWrapping/examples/ols/src/ols.jl
+++ b/JuliaLibWrapping/examples/ols/src/ols.jl
@@ -5,7 +5,7 @@ module ols
 # `fit` returns a struct embedding a `JLWStatus` (so its façade wrapper is
 # the hand-edited path), `predict` returns `JLWStatus` directly (the
 # auto-wrapped path that raises `JLWError` on failure), and `summary_report`
-# writes into a caller-allocated `CString` buffer.
+# writes into a caller-allocated `CString{:borrowed}` buffer.
 
 using JLWInterop
 using LinearAlgebra
@@ -78,7 +78,7 @@ Base.@ccallable function predict(coeffs::CVector{:borrowed, Float64},
     return jlw_ok()
 end
 
-Base.@ccallable function summary_report(result::FitResult, buf::CString)::JLWStatus
+Base.@ccallable function summary_report(result::FitResult, buf::CString{:borrowed})::JLWStatus
     if result.status.code != 0
         return jlw_error(101, "result has non-zero status; nothing to report")
     end

--- a/JuliaLibWrapping/src/python.jl
+++ b/JuliaLibWrapping/src/python.jl
@@ -287,10 +287,8 @@ end
 Return the mangled Python `ctypes.Structure` class name for the
 `CString` struct pointed to by `desc`'s field named `fieldname`
 (`"data"` for [`cstrarray_struct_info`](@ref), `"keys"` for
-[`cdict_struct_info`](@ref)). Callers must have already confirmed the field
-recognizes as `Ptr{CString}`. `typedict` already carries the pointee's class
-name by the time this is called — every struct is pre-mangled, in
-declaration order, before `_write_bindings` walks `typeinfo`.
+[`cdict_struct_info`](@ref)). The caller must first verify that the field
+points to a `CString` with matching ownership.
 """
 function _cstring_pointee_classname(
         desc::StructDesc, fieldname::String,
@@ -551,31 +549,39 @@ function _write_carray_helpers(f::IO, cainfo, release_present::Bool)
     )
 end
 
-function _write_cstring_helpers(f::IO)
+"""
+    _write_cstring_helpers(f, csinfo, release_present)
+
+Emit conversion methods for a recognized `CString` `ctypes` class. Borrowed
+classes also get constructors; owned classes get `free()`.
+"""
+function _write_cstring_helpers(f::IO, csinfo, release_present::Bool)
     # CString helpers use ctypes only.
-    println(f, "")
-    println(f, "    @classmethod")
-    println(f, "    def from_str(cls, s):")
-    println(f, "        \"\"\"Return a CString whose buffer holds the UTF-8 encoding of `s`.")
-    println(f, "")
-    println(f, "        Allocates a fresh ctypes buffer and copies the bytes into it; the")
-    println(f, "        returned object holds a reference to that buffer, so the caller")
-    println(f, "        must keep it alive for the duration of any C call that uses it.\"\"\"")
-    println(f, "        if not isinstance(s, str):")
-    println(f, "            raise TypeError(f\"expected str, got {type(s).__name__}\")")
-    println(f, "        return cls.from_bytes(s.encode(\"utf-8\"))")
-    println(f, "")
-    println(f, "    @classmethod")
-    println(f, "    def from_bytes(cls, b):")
-    println(f, "        \"\"\"Return a CString whose buffer holds a copy of the bytes `b`.\"\"\"")
-    println(f, "        if not isinstance(b, (bytes, bytearray)):")
-    println(f, "            raise TypeError(f\"expected bytes-like, got {type(b).__name__}\")")
-    println(f, "        n = len(b)")
-    println(f, "        buf = (ctypes.c_uint8 * n).from_buffer_copy(b) if n else (ctypes.c_uint8 * 0)()")
-    println(f, "        obj = cls(length=n,")
-    println(f, "                  data=ctypes.cast(buf, ctypes.POINTER(ctypes.c_uint8)))")
-    println(f, "        obj._buffer = buf")
-    println(f, "        return obj")
+    if csinfo.ownership === :borrowed
+        println(f, "")
+        println(f, "    @classmethod")
+        println(f, "    def from_str(cls, s):")
+        println(f, "        \"\"\"Return a CString whose buffer holds the UTF-8 encoding of `s`.")
+        println(f, "")
+        println(f, "        Allocates a fresh ctypes buffer and copies the bytes into it; the")
+        println(f, "        returned object holds a reference to that buffer, so the caller")
+        println(f, "        must keep it alive for the duration of any C call that uses it.\"\"\"")
+        println(f, "        if not isinstance(s, str):")
+        println(f, "            raise TypeError(f\"expected str, got {type(s).__name__}\")")
+        println(f, "        return cls.from_bytes(s.encode(\"utf-8\"))")
+        println(f, "")
+        println(f, "    @classmethod")
+        println(f, "    def from_bytes(cls, b):")
+        println(f, "        \"\"\"Return a CString whose buffer holds a copy of the bytes `b`.\"\"\"")
+        println(f, "        if not isinstance(b, (bytes, bytearray)):")
+        println(f, "            raise TypeError(f\"expected bytes-like, got {type(b).__name__}\")")
+        println(f, "        n = len(b)")
+        println(f, "        buf = (ctypes.c_uint8 * n).from_buffer_copy(b) if n else (ctypes.c_uint8 * 0)()")
+        println(f, "        obj = cls(length=n,")
+        println(f, "                  data=ctypes.cast(buf, ctypes.POINTER(ctypes.c_uint8)))")
+        println(f, "        obj._buffer = buf")
+        println(f, "        return obj")
+    end
     println(f, "")
     println(f, "    def as_bytes(self):")
     println(f, "        \"\"\"Return a copy of the underlying bytes as a Python `bytes` object.\"\"\"")
@@ -583,7 +589,13 @@ function _write_cstring_helpers(f::IO)
     println(f, "")
     println(f, "    def as_str(self):")
     println(f, "        \"\"\"Return the underlying bytes decoded as UTF-8.\"\"\"")
-    return println(f, "        return self.as_bytes().decode(\"utf-8\")")
+    println(f, "        return self.as_bytes().decode(\"utf-8\")")
+    csinfo.ownership === :owned || return nothing
+    return _emit_owned_free_method(
+        f, "buffer",
+        ["        _lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))"],
+        release_present
+    )
 end
 
 """
@@ -870,15 +882,16 @@ function _write_bindings(
                 println(f, "    ]")
             end
             cainfo = _python_carray_info(type, typeinfo)
+            csinfo = cstring_struct_info(type, typeinfo)
             csainfo = cstrarray_struct_info(type, typeinfo)
             cdinfo = _python_cdict_info(type, typeinfo)
             coinfo = _python_copt_info(type, typeinfo)
             if cainfo !== nothing
                 # Emit numpy helpers for supported CArray layouts.
                 _write_carray_helpers(f, cainfo, release_present)
-            elseif cstring_struct_info(type, typeinfo)
+            elseif !isnothing(csinfo)
                 # Emit CString conversion helpers.
-                _write_cstring_helpers(f)
+                _write_cstring_helpers(f, csinfo, release_present)
             elseif !isnothing(csainfo)
                 # Emit CStrArray conversion helpers.
                 cs_classname = _cstring_pointee_classname(type, "data", typeinfo, typedict)
@@ -964,7 +977,8 @@ Classify a method argument for façade auto-wrapping. The return is one of:
 - `(kind=:primitive,)` — pass-through
 - `(kind=:carray, classname=…)` — a borrowed `CArray`; wrap with
   `<class>.from_numpy(name)`
-- `(kind=:cstring, classname=…)` — wrap with `<class>.from_str(name)`
+- `(kind=:cstring, classname=…)` — a borrowed `CString`; wrap with
+  `<class>.from_str(name)`
 - `(kind=:cstrarray, classname=…)` — a borrowed `CStrArray`; wrap with
   `<class>.from_list(name)`
 - `(kind=:cdict, classname=…)` — a borrowed `CDict`; wrap with
@@ -982,6 +996,7 @@ function _facade_classify_arg(
         return (kind = :primitive,)
     elseif t isa StructDesc
         cainfo = _python_carray_info(t, typeinfo)
+        csinfo = cstring_struct_info(t, typeinfo)
         csainfo = cstrarray_struct_info(t, typeinfo)
         cdinfo = _python_cdict_info(t, typeinfo)
         if !isnothing(cainfo)
@@ -992,7 +1007,13 @@ function _facade_classify_arg(
                 reason = "argument transfers CArray ownership into the library; hand-wrap",
             )
             return (kind = :carray, classname = typedict[arg.type])
-        elseif cstring_struct_info(t, typeinfo)
+        elseif !isnothing(csinfo)
+            # An owning CString argument hands Julia-allocated storage into the
+            # library, which then owns the release. Python cannot supply that.
+            csinfo.ownership === :owned && return (
+                kind = :opaque,
+                reason = "argument transfers CString ownership into the library; hand-wrap",
+            )
             return (kind = :cstring, classname = typedict[arg.type])
         elseif !isnothing(csainfo)
             # An owning CStrArray argument hands Julia-allocated storage into
@@ -1036,7 +1057,12 @@ The return is one of:
   `try`, copy into a fresh numpy array (`np.array(_result.as_numpy(),
   copy=True)`) FIRST — never hand back a view over memory about to be freed
   — then a `finally` calls `_result.free()`.
-- `(kind=:cstring_unwrap, classname=…)` — return `_result.as_str()`
+- `(kind=:cstring_convert, classname=…)` — a borrowed `CString` return:
+  `return _result.as_str()`. `as_str` copies, so the result outlives the
+  buffer; nothing is released. Not gated on `release_present`.
+- `(kind=:cstring_unwrap, classname=…)` — an owning `CString` return: inside a
+  `try`, `_out = _result.as_str()` (a real copy, independent of the buffer);
+  a `finally` then calls `_result.free()`, releasing `data` via `jlw_free`.
 - `(kind=:cstrarray_convert, classname=…)` — a borrowed `CStrArray` return:
   `return _result.as_list()`. `as_list` copies, so the result outlives the
   buffer; nothing is released. Not gated on `release_present`.
@@ -1054,9 +1080,9 @@ The return is one of:
   is by-value, so no free is involved (not gated on `release_present`)
 - `(kind=:jlwstatus_discard,)` — direct `JLWStatus` return; discard, return `None`
 - `(kind=:opaque, reason=…)` — bail out. Also returned in place of
-  `:carray_unwrap`/`:cstrarray_unwrap`/`:cdict_unwrap` when `release_present`
-  is `false`: auto-wrapping an owning return with no release entrypoints
-  available would emit a call to a symbol that does not exist.
+  `:carray_unwrap`/`:cstring_unwrap`/`:cstrarray_unwrap`/`:cdict_unwrap` when
+  `release_present` is `false`: auto-wrapping an owning return with no release
+  entrypoints available would emit a call to a symbol that does not exist.
 """
 function _facade_classify_return(
         method::MethodDesc,
@@ -1070,6 +1096,7 @@ function _facade_classify_return(
         return (kind = :passthrough,)
     elseif rt isa StructDesc
         cainfo = _python_carray_info(rt, typeinfo)
+        csinfo = cstring_struct_info(rt, typeinfo)
         csainfo = cstrarray_struct_info(rt, typeinfo)
         cdinfo = _python_cdict_info(rt, typeinfo)
         if is_jlwstatus_struct(rt, typeinfo)
@@ -1082,7 +1109,13 @@ function _facade_classify_return(
                 reason = "owning return needs release entrypoints; add JLWInterop.@export_release_entrypoints to the library",
             )
             return (kind = :carray_unwrap, classname = typedict[method.return_type])
-        elseif cstring_struct_info(rt, typeinfo)
+        elseif !isnothing(csinfo)
+            csinfo.ownership === :borrowed &&
+                return (kind = :cstring_convert, classname = typedict[method.return_type])
+            release_present || return (
+                kind = :opaque,
+                reason = "owning return needs release entrypoints; add JLWInterop.@export_release_entrypoints to the library",
+            )
             return (kind = :cstring_unwrap, classname = typedict[method.return_type])
         elseif !isnothing(csainfo)
             csainfo.ownership === :borrowed &&
@@ -1159,7 +1192,7 @@ function _facade_plan(
         ret.kind in (:carray_view, :carray_unwrap)
     adds_value = any(c -> c.kind !== :primitive, arg_classes) ||
         ret.kind in (
-        :carray_view, :carray_unwrap, :cstring_unwrap,
+        :carray_view, :carray_unwrap, :cstring_convert, :cstring_unwrap,
         :cstrarray_convert, :cstrarray_unwrap, :cdict_convert, :cdict_unwrap,
         :copt_unwrap, :jlwstatus_discard,
     )
@@ -1229,9 +1262,20 @@ function _emit_facade_autowrapper(f::IO, method::MethodDesc, plan)
         println(f, "    finally:")
         println(f, "        _result.free()")
         println(f, "    return _out")
-    elseif ret.kind === :cstring_unwrap
+    elseif ret.kind === :cstring_convert
+        # The storage belongs to the caller; `as_str` copies, so there is
+        # nothing to release.
         println(f, "    _result = ", call)
         println(f, "    return _result.as_str()")
+    elseif ret.kind === :cstring_unwrap
+        # Decode to a Python `str` first (a real copy, independent of the
+        # buffer), THEN free `data` via `jlw_free` in `finally`.
+        println(f, "    _result = ", call)
+        println(f, "    try:")
+        println(f, "        _out = _result.as_str()")
+        println(f, "    finally:")
+        println(f, "        _result.free()")
+        println(f, "    return _out")
     elseif ret.kind === :cstrarray_convert
         # The storage belongs to the caller; `as_list` copies, so there is
         # nothing to release.
@@ -1290,7 +1334,7 @@ function _write_facade_stub(
     println(f)
     println(f, "This file is generated **once** by JuliaLibWrapping as a starter")
     println(f, "façade. Functions whose arguments and return are all recognized")
-    println(f, "(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)")
+    println(f, "(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)")
     println(f, "are wrapped to accept and return idiomatic Python objects (numpy")
     println(f, "arrays, `str`). Anything else is re-exported from `_lowlevel`")
     println(f, "with a `TODO` comment naming what needs hand-wrapping.")

--- a/JuliaLibWrapping/src/recognizers.jl
+++ b/JuliaLibWrapping/src/recognizers.jl
@@ -67,33 +67,30 @@ function jlwstatus_location(method::MethodDesc, typeinfo::OrderedDict{Int, TypeD
 end
 
 """
-    cstring_struct_info(desc::StructDesc, typeinfo) -> Bool
+    cstring_struct_info(desc::StructDesc, typeinfo) -> Union{Nothing, NamedTuple}
 
-Recognize `CString` by name and field layout. Field order is unrestricted.
+Recognize `CString` by name and field layout. The name must carry an explicit
+leading ownership parameter (see [`_carrier_ownership`](@ref)) and the layout
+must be exactly two fields: `length`, a primitive integer, and `data`, a
+pointer to `UInt8`. Field order is unrestricted. On a match, return
+`(; ownership)` — `:owned` or `:borrowed`. Otherwise return `nothing`;
+ownership is never inferred from a name that does not state it.
 """
 function cstring_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
-    startswith(desc.name, "CString") || return false
-    length(desc.fields) == 2 || return false
-    length_field = nothing
-    data_field = nothing
-    for field in desc.fields
-        if field.name == "length"
-            length_field = field
-        elseif field.name == "data"
-            data_field = field
-        end
-    end
-    (isnothing(length_field) || isnothing(data_field)) && return false
-    length_type = typeinfo[length_field.type]
-    length_type isa PrimitiveTypeDesc || return false
-    (startswith(length_type.name, "Int") || startswith(length_type.name, "UInt")) || return false
-    data_type = typeinfo[data_field.type]
-    data_type isa PointerDesc || return false
-    data_type.pointee_type === nothing && return false # `void` pointee
+    ownership = _carrier_ownership(desc.name, ("CString{",))
+    isnothing(ownership) && return nothing
+    m = _match_fields(desc, ("length", "data"))
+    isnothing(m) && return nothing
+    length_type = typeinfo[m.length.type]
+    length_type isa PrimitiveTypeDesc || return nothing
+    (startswith(length_type.name, "Int") || startswith(length_type.name, "UInt")) || return nothing
+    data_type = typeinfo[m.data.type]
+    data_type isa PointerDesc || return nothing
+    data_type.pointee_type === nothing && return nothing # `void` pointee
     pointee = typeinfo[data_type.pointee_type]
-    pointee isa PrimitiveTypeDesc || return false
-    pointee.name == "UInt8" || return false
-    return true
+    pointee isa PrimitiveTypeDesc || return nothing
+    pointee.name == "UInt8" || return nothing
+    return (; ownership)
 end
 
 """
@@ -102,10 +99,10 @@ end
 Recognize `CStrArray` by name and field layout. The name must carry an
 explicit leading ownership parameter (see [`_carrier_ownership`](@ref)) and
 the layout must be exactly two fields: `length`, a signed primitive integer,
-and `data`, a pointer to a struct matching [`cstring_struct_info`](@ref).
-Field order is unrestricted. On a match, return `(; ownership)` — `:owned` or
-`:borrowed`. Otherwise return `nothing`; ownership is never inferred from a
-name that does not state it.
+and `data`, a pointer to a struct matching [`cstring_struct_info`](@ref) whose
+own ownership is the same. Field order is unrestricted. On a match, return
+`(; ownership)` — `:owned` or `:borrowed`. Otherwise return `nothing`;
+ownership is never inferred from a name that does not state it.
 """
 function cstrarray_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
     ownership = _carrier_ownership(desc.name, ("CStrArray{",))
@@ -119,7 +116,9 @@ function cstrarray_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, Type
     data_type.pointee_type === nothing && return nothing # `void` pointee
     pointee = typeinfo[data_type.pointee_type]
     pointee isa StructDesc || return nothing
-    cstring_struct_info(pointee, typeinfo) || return nothing
+    element = cstring_struct_info(pointee, typeinfo)
+    isnothing(element) && return nothing
+    element.ownership === ownership || return nothing
     return (; ownership)
 end
 
@@ -129,11 +128,11 @@ end
 Recognize `CDict` by name and field layout. The name must carry an explicit
 leading ownership parameter (see [`_carrier_ownership`](@ref)) and the layout
 must be exactly three fields: `length`, a primitive integer; `keys`, a pointer
-to a struct matching [`cstring_struct_info`](@ref); and `values`, a pointer to
-a primitive type. On a match, return `(; value_type, ownership)` — the Julia
-name of the value type (e.g. `"Float64"`) and `:owned` or `:borrowed`.
-Otherwise return `nothing`; ownership is never inferred from a name that does
-not state it.
+to a struct matching [`cstring_struct_info`](@ref) whose own ownership is the
+same; and `values`, a pointer to a primitive type. On a match, return
+`(; value_type, ownership)` — the Julia name of the value type (e.g.
+`"Float64"`) and `:owned` or `:borrowed`. Otherwise return `nothing`;
+ownership is never inferred from a name that does not state it.
 """
 function cdict_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
     ownership = _carrier_ownership(desc.name, ("CDict{",))
@@ -148,7 +147,9 @@ function cdict_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc
     keys_type.pointee_type === nothing && return nothing # `void` pointee
     keys_pointee = typeinfo[keys_type.pointee_type]
     keys_pointee isa StructDesc || return nothing
-    cstring_struct_info(keys_pointee, typeinfo) || return nothing
+    key = cstring_struct_info(keys_pointee, typeinfo)
+    isnothing(key) && return nothing
+    key.ownership === ownership || return nothing
     values_type = typeinfo[m.values.type]
     values_type isa PointerDesc || return nothing
     values_type.pointee_type === nothing && return nothing # `void` pointee

--- a/JuliaLibWrapping/test/bindinginfo_carray_owned.json
+++ b/JuliaLibWrapping/test/bindinginfo_carray_owned.json
@@ -18,7 +18,7 @@
     },
     {
       "symbol": "jlw_free_strings",
-      "name": "jlw_free_strings(p::Ptr{CString}, n::Int64)",
+      "name": "jlw_free_strings(p::Ptr{CString{:owned}}, n::Int64)",
       "arguments": [
         { "name": "p", "type_id": 10 },
         { "name": "n", "type_id": 3 }
@@ -98,7 +98,7 @@
     {
       "id": 9,
       "kind": "struct",
-      "name": "CString",
+      "name": "CString{:owned}",
       "size": 16,
       "alignment": 8,
       "fields": [
@@ -109,7 +109,7 @@
     {
       "id": 10,
       "kind": "pointer",
-      "name": "Ptr{CString}",
+      "name": "Ptr{CString{:owned}}",
       "pointee_type_id": 9
     },
     {

--- a/JuliaLibWrapping/test/bindinginfo_carray_owned_nofree.json
+++ b/JuliaLibWrapping/test/bindinginfo_carray_owned_nofree.json
@@ -81,7 +81,7 @@
     {
       "id": 9,
       "kind": "struct",
-      "name": "CString",
+      "name": "CString{:owned}",
       "size": 16,
       "alignment": 8,
       "fields": [
@@ -92,7 +92,7 @@
     {
       "id": 10,
       "kind": "pointer",
-      "name": "Ptr{CString}",
+      "name": "Ptr{CString{:owned}}",
       "pointee_type_id": 9
     },
     {

--- a/JuliaLibWrapping/test/bindinginfo_cdict.json
+++ b/JuliaLibWrapping/test/bindinginfo_cdict.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Synthetic fixture for the CDict vocabulary type. Mirrors the layout juliac would emit for `struct CDict{owned,V}; length::Int64; keys::Ptr{CString}; values::Ptr{V}; end` (JLWInterop) instantiated at V=Float64, with one @ccallable function taking a `CDict{:borrowed, Float64}` argument and one returning a `CDict{:owned, Float64}`, plus the macro-emitted `jlw_free`/`jlw_free_strings` release entrypoints so the owning return is `:auto`, not `:mechanical`. `keys` and `values` are two SEPARATE allocations: keys are length-prefixed `CString`s freed with `jlw_free_strings`, values a dense buffer freed with `jlw_free`. Ownership is a leading Symbol type parameter carried in the ABI JSON name, so the two ownerships are two distinct 24-byte structs with an identical `(length, keys, values)` layout. `jlw_free` takes a `Ptr{Nothing}` (a pointer with a null pointee id) and both release entrypoints return void (a null return type id), mirroring juliac's actual ABI JSON rendering. The Python emitter must emit `from_dict`/`as_dict` on the borrowed class, `as_dict`/`free` on the owning class, and an owning-return convert-then-free facade wrapper.",
+  "_comment": "Synthetic fixture for the CDict vocabulary type. Mirrors the layout juliac would emit for `struct CDict{owned,V}; length::Int64; keys::Ptr{CString{owned}}; values::Ptr{V}; end` (JLWInterop) instantiated at V=Float64, with one @ccallable function taking a `CDict{:borrowed, Float64}` argument and one returning a `CDict{:owned, Float64}`, plus the macro-emitted `jlw_free`/`jlw_free_strings` release entrypoints so the owning return is `:auto`, not `:mechanical`. `keys` and `values` are two SEPARATE allocations: keys are length-prefixed `CString`s carrying the dictionary's ownership (so the two dictionaries point at two distinct `CString` structs) and freed with `jlw_free_strings`, values a dense buffer freed with `jlw_free`. Ownership is a leading Symbol type parameter carried in the ABI JSON name, so the two ownerships are two distinct 24-byte structs with an identical `(length, keys, values)` layout. `jlw_free` takes a `Ptr{Nothing}` (a pointer with a null pointee id) and both release entrypoints return void (a null return type id), mirroring juliac's actual ABI JSON rendering. The Python emitter must emit `from_dict`/`as_dict` on the borrowed class, `as_dict`/`free` on the owning class, and an owning-return convert-then-free facade wrapper.",
   "types": [
     {
       "kind": "primitive",
@@ -45,7 +45,7 @@
     },
     {
       "kind": "struct",
-      "name": "CString",
+      "name": "CString{:borrowed}",
       "id": 6,
       "size": 16,
       "fields": [
@@ -56,7 +56,7 @@
     },
     {
       "kind": "pointer",
-      "name": "Ptr{CString}",
+      "name": "Ptr{CString{:borrowed}}",
       "id": 7,
       "pointee_type_id": 6
     },
@@ -85,7 +85,7 @@
       "size": 24,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "keys", "type_id": 7, "offset": 8, "isptr": false, "isfieldatomic": false },
+        { "name": "keys", "type_id": 13, "offset": 8, "isptr": false, "isfieldatomic": false },
         { "name": "values", "type_id": 8, "offset": 16, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -95,6 +95,23 @@
       "name": "Ptr{Nothing}",
       "id": 10,
       "pointee_type_id": null
+    },
+    {
+      "kind": "struct",
+      "name": "CString{:owned}",
+      "id": 12,
+      "size": 16,
+      "fields": [
+        { "name": "length", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "data", "type_id": 4, "offset": 8, "isptr": false, "isfieldatomic": false }
+      ],
+      "alignment": 8
+    },
+    {
+      "kind": "pointer",
+      "name": "Ptr{CString{:owned}}",
+      "id": 13,
+      "pointee_type_id": 12
     }
   ],
   "functions": [
@@ -122,9 +139,9 @@
     },
     {
       "returns": { "type_id": null },
-      "name": "jlw_free_strings(p::Ptr{CString}, n::Int64)",
+      "name": "jlw_free_strings(p::Ptr{CString{:owned}}, n::Int64)",
       "arguments": [
-        { "name": "p", "type_id": 7 },
+        { "name": "p", "type_id": 13 },
         { "name": "n", "type_id": 2 }
       ],
       "symbol": "jlw_free_strings"

--- a/JuliaLibWrapping/test/bindinginfo_cdict_int32.json
+++ b/JuliaLibWrapping/test/bindinginfo_cdict_int32.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Fixture identical in shape to bindinginfo_cdict.json, but instantiated at V=Int32 instead of V=Float64 \u2014 proves cdict_struct_info's value-type parameterization (and the helper codegen that substitutes the matching ctypes name) varies correctly beyond a single value type. Field offsets (0, 8, 16, size 24) are IDENTICAL to the Float64 case: `values` is a pointer field (8 bytes) regardless of what it points at, so the pointee's own size never affects CDict's own layout. `keys`/`jlw_free_strings` are unaffected by the value type (always Ptr{CString}); only `values`'s pointee type and the Float64->Int32 substitution in from_dict/as_dict's value ctype differ from bindinginfo_cdict.json.",
+  "_comment": "Fixture identical in shape to bindinginfo_cdict.json, but instantiated at V=Int32 instead of V=Float64 \u2014 proves cdict_struct_info's value-type parameterization (and the helper codegen that substitutes the matching ctypes name) varies correctly beyond a single value type. Field offsets (0, 8, 16, size 24) are IDENTICAL to the Float64 case: `values` is a pointer field (8 bytes) regardless of what it points at, so the pointee's own size never affects CDict's own layout. `keys`/`jlw_free_strings` are unaffected by the value type (always Ptr{CString{owned}} for the owning dictionary); only `values`'s pointee type and the Float64->Int32 substitution in from_dict/as_dict's value ctype differ from bindinginfo_cdict.json.",
   "types": [
     {
       "kind": "primitive",
@@ -36,7 +36,7 @@
     },
     {
       "kind": "struct",
-      "name": "CString",
+      "name": "CString{:borrowed}",
       "id": 5,
       "size": 16,
       "fields": [
@@ -47,7 +47,7 @@
     },
     {
       "kind": "pointer",
-      "name": "Ptr{CString}",
+      "name": "Ptr{CString{:borrowed}}",
       "id": 6,
       "pointee_type_id": 5
     },
@@ -76,7 +76,7 @@
       "size": 24,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "keys", "type_id": 6, "offset": 8, "isptr": false, "isfieldatomic": false },
+        { "name": "keys", "type_id": 12, "offset": 8, "isptr": false, "isfieldatomic": false },
         { "name": "values", "type_id": 7, "offset": 16, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -86,6 +86,23 @@
       "name": "Ptr{Nothing}",
       "id": 9,
       "pointee_type_id": null
+    },
+    {
+      "kind": "struct",
+      "name": "CString{:owned}",
+      "id": 11,
+      "size": 16,
+      "fields": [
+        { "name": "length", "type_id": 1, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "data", "type_id": 4, "offset": 8, "isptr": false, "isfieldatomic": false }
+      ],
+      "alignment": 8
+    },
+    {
+      "kind": "pointer",
+      "name": "Ptr{CString{:owned}}",
+      "id": 12,
+      "pointee_type_id": 11
     }
   ],
   "functions": [
@@ -113,9 +130,9 @@
     },
     {
       "returns": { "type_id": null },
-      "name": "jlw_free_strings(p::Ptr{CString}, n::Int64)",
+      "name": "jlw_free_strings(p::Ptr{CString{:owned}}, n::Int64)",
       "arguments": [
-        { "name": "p", "type_id": 6 },
+        { "name": "p", "type_id": 12 },
         { "name": "n", "type_id": 2 }
       ],
       "symbol": "jlw_free_strings"

--- a/JuliaLibWrapping/test/bindinginfo_cdict_nofree.json
+++ b/JuliaLibWrapping/test/bindinginfo_cdict_nofree.json
@@ -45,7 +45,7 @@
     },
     {
       "kind": "struct",
-      "name": "CString",
+      "name": "CString{:borrowed}",
       "id": 6,
       "size": 16,
       "fields": [
@@ -56,7 +56,7 @@
     },
     {
       "kind": "pointer",
-      "name": "Ptr{CString}",
+      "name": "Ptr{CString{:borrowed}}",
       "id": 7,
       "pointee_type_id": 6
     },
@@ -85,7 +85,7 @@
       "size": 24,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "keys", "type_id": 7, "offset": 8, "isptr": false, "isfieldatomic": false },
+        { "name": "keys", "type_id": 13, "offset": 8, "isptr": false, "isfieldatomic": false },
         { "name": "values", "type_id": 8, "offset": 16, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -95,6 +95,23 @@
       "name": "Ptr{Nothing}",
       "id": 10,
       "pointee_type_id": null
+    },
+    {
+      "kind": "struct",
+      "name": "CString{:owned}",
+      "id": 12,
+      "size": 16,
+      "fields": [
+        { "name": "length", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "data", "type_id": 4, "offset": 8, "isptr": false, "isfieldatomic": false }
+      ],
+      "alignment": 8
+    },
+    {
+      "kind": "pointer",
+      "name": "Ptr{CString{:owned}}",
+      "id": 13,
+      "pointee_type_id": 12
     }
   ],
   "functions": [

--- a/JuliaLibWrapping/test/bindinginfo_cstrarray.json
+++ b/JuliaLibWrapping/test/bindinginfo_cstrarray.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Synthetic fixture for the CStrArray vocabulary type. Mirrors the layout juliac would emit for `struct CStrArray{owned}; length::Int64; data::Ptr{CString}; end` (JLWInterop), with one @ccallable function taking a `CStrArray{:borrowed}` argument and one returning a `CStrArray{:owned}`, plus the macro-emitted `jlw_free`/`jlw_free_strings` release entrypoints so the owning return is `:auto`, not `:mechanical`. `data` points to length-prefixed `CString` elements (`struct CString; length::Int32; data::Ptr{UInt8}; end`, size 16, offsets 0/8) rather than NUL-terminated `Ptr{UInt8}`s. Ownership is a leading Symbol type parameter carried in the ABI JSON name, so the two ownerships are two distinct 16-byte structs with an identical `(length, data)` layout. `jlw_free` takes a `Ptr{Nothing}` (a pointer with a null pointee id) and both release entrypoints return void (a null return type id), mirroring juliac's actual ABI JSON rendering. The Python emitter must recognize the CStrArray shape (ownership token in the name + pointee-is-CString shape, not just the name) and emit `from_list`/`as_list` on the borrowed class, `as_list`/`free` on the owning class, and an owning-return convert-then-free facade wrapper.",
+  "_comment": "Synthetic fixture for the CStrArray vocabulary type. Mirrors the layout juliac would emit for `struct CStrArray{owned}; length::Int64; data::Ptr{CString{owned}}; end` (JLWInterop), with one @ccallable function taking a `CStrArray{:borrowed}` argument and one returning a `CStrArray{:owned}`, plus the macro-emitted `jlw_free`/`jlw_free_strings` release entrypoints so the owning return is `:auto`, not `:mechanical`. `data` points to length-prefixed `CString` elements (`struct CString{owned}; length::Int32; data::Ptr{UInt8}; end`, size 16, offsets 0/8) rather than NUL-terminated `Ptr{UInt8}`s, and each element carries the container's ownership, so the two containers point at two distinct `CString` structs. Ownership is a leading Symbol type parameter carried in the ABI JSON name, so the two ownerships are two distinct 16-byte structs with an identical `(length, data)` layout. `jlw_free` takes a `Ptr{Nothing}` (a pointer with a null pointee id) and both release entrypoints return void (a null return type id), mirroring juliac's actual ABI JSON rendering. The Python emitter must recognize the CStrArray shape (ownership token in the name + pointee-is-CString shape, not just the name) and emit `from_list`/`as_list` on the borrowed class, `as_list`/`free` on the owning class, and an owning-return convert-then-free facade wrapper.",
   "types": [
     {
       "kind": "primitive",
@@ -36,7 +36,7 @@
     },
     {
       "kind": "struct",
-      "name": "CString",
+      "name": "CString{:borrowed}",
       "id": 5,
       "size": 16,
       "fields": [
@@ -47,7 +47,7 @@
     },
     {
       "kind": "pointer",
-      "name": "Ptr{CString}",
+      "name": "Ptr{CString{:borrowed}}",
       "id": 6,
       "pointee_type_id": 5
     },
@@ -69,7 +69,7 @@
       "size": 16,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 6, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 11, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
@@ -78,6 +78,23 @@
       "name": "Ptr{Nothing}",
       "id": 8,
       "pointee_type_id": null
+    },
+    {
+      "kind": "struct",
+      "name": "CString{:owned}",
+      "id": 10,
+      "size": 16,
+      "fields": [
+        { "name": "length", "type_id": 4, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
+      ],
+      "alignment": 8
+    },
+    {
+      "kind": "pointer",
+      "name": "Ptr{CString{:owned}}",
+      "id": 11,
+      "pointee_type_id": 10
     }
   ],
   "functions": [
@@ -105,9 +122,9 @@
     },
     {
       "returns": { "type_id": null },
-      "name": "jlw_free_strings(p::Ptr{CString}, n::Int64)",
+      "name": "jlw_free_strings(p::Ptr{CString{:owned}}, n::Int64)",
       "arguments": [
-        { "name": "p", "type_id": 6 },
+        { "name": "p", "type_id": 11 },
         { "name": "n", "type_id": 2 }
       ],
       "symbol": "jlw_free_strings"

--- a/JuliaLibWrapping/test/bindinginfo_cstrarray_nofree.json
+++ b/JuliaLibWrapping/test/bindinginfo_cstrarray_nofree.json
@@ -36,7 +36,7 @@
     },
     {
       "kind": "struct",
-      "name": "CString",
+      "name": "CString{:borrowed}",
       "id": 5,
       "size": 16,
       "fields": [
@@ -47,7 +47,7 @@
     },
     {
       "kind": "pointer",
-      "name": "Ptr{CString}",
+      "name": "Ptr{CString{:borrowed}}",
       "id": 6,
       "pointee_type_id": 5
     },
@@ -69,7 +69,7 @@
       "size": 16,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 6, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 11, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
@@ -78,6 +78,23 @@
       "name": "Ptr{Nothing}",
       "id": 8,
       "pointee_type_id": null
+    },
+    {
+      "kind": "struct",
+      "name": "CString{:owned}",
+      "id": 10,
+      "size": 16,
+      "fields": [
+        { "name": "length", "type_id": 4, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
+      ],
+      "alignment": 8
+    },
+    {
+      "kind": "pointer",
+      "name": "Ptr{CString{:owned}}",
+      "id": 11,
+      "pointee_type_id": 10
     }
   ],
   "functions": [

--- a/JuliaLibWrapping/test/bindinginfo_cstring.json
+++ b/JuliaLibWrapping/test/bindinginfo_cstring.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Hand-authored fixture for the CString vocabulary type. Mirrors the layout juliac would emit for `struct CString; length::Int32; data::Ptr{UInt8}; end`, with one @ccallable function consuming a CString and one returning one. The Python emitter must recognize this shape by name + field layout and emit from_str / as_str / from_bytes / as_bytes helpers.",
+  "_comment": "Hand-authored fixture for a borrowed CString. Mirrors the layout juliac would emit for `struct CString{owned}; length::Int32; data::Ptr{UInt8}; end` instantiated at :borrowed, with one @ccallable function consuming a `CString{:borrowed}` and one returning one. Ownership is a leading Symbol type parameter carried in the ABI JSON name, and a name that states no ownership is not recognized at all. The Python emitter must recognize this shape by name + field layout and emit from_str / as_str / from_bytes / as_bytes helpers and no free(): the buffer belongs to the caller, so the facade converts str in and str out and releases nothing.",
   "types": [
     {
       "kind": "primitive",
@@ -27,7 +27,7 @@
     },
     {
       "kind": "struct",
-      "name": "CString",
+      "name": "CString{:borrowed}",
       "id": 4,
       "size": 16,
       "fields": [
@@ -40,7 +40,7 @@
   "functions": [
     {
       "returns": { "type_id": 2 },
-      "name": "greeting_length(s::CString)",
+      "name": "greeting_length(s::CString{:borrowed})",
       "arguments": [
         { "name": "s", "type_id": 4 }
       ],

--- a/JuliaLibWrapping/test/bindinginfo_cstring_owned.json
+++ b/JuliaLibWrapping/test/bindinginfo_cstring_owned.json
@@ -1,0 +1,86 @@
+{
+  "_comment": "Hand-authored fixture for an owning CString return. Mirrors the layout juliac would emit for `struct CString{owned}; length::Int32; data::Ptr{UInt8}; end` instantiated at :owned, with one @ccallable function returning a freshly allocated `CString{:owned}`, plus the macro-emitted jlw_free/jlw_free_strings release entrypoints so the owning return is `:auto` (decode, then free in a `finally`), not `:mechanical`. The two ownerships are two distinct 16-byte structs with an identical `(length, data)` layout, so only the name distinguishes them; bindinginfo_cstring.json covers the borrowed side. `jlw_free` takes a `Ptr{Nothing}` (a pointer with a null pointee id) and both release entrypoints return void (a null return type id), mirroring juliac's actual ABI JSON rendering. The Python emitter must emit as_str/as_bytes and an idempotent free() on the owning class, and no from_str/from_bytes: Python has no Julia allocation to hand over.",
+  "types": [
+    {
+      "kind": "primitive",
+      "name": "UInt8",
+      "id": 1,
+      "size": 1,
+      "bits": 8,
+      "signed": false,
+      "alignment": 1
+    },
+    {
+      "kind": "primitive",
+      "name": "Int32",
+      "id": 2,
+      "size": 4,
+      "bits": 32,
+      "signed": true,
+      "alignment": 4
+    },
+    {
+      "kind": "pointer",
+      "name": "Ptr{UInt8}",
+      "id": 3,
+      "pointee_type_id": 1
+    },
+    {
+      "kind": "struct",
+      "name": "CString{:owned}",
+      "id": 4,
+      "size": 16,
+      "fields": [
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
+      ],
+      "alignment": 8
+    },
+    {
+      "kind": "pointer",
+      "name": "Ptr{CString{:owned}}",
+      "id": 5,
+      "pointee_type_id": 4
+    },
+    {
+      "kind": "primitive",
+      "name": "Int64",
+      "id": 6,
+      "size": 8,
+      "bits": 64,
+      "signed": true,
+      "alignment": 8
+    },
+    {
+      "kind": "pointer",
+      "name": "Ptr{Nothing}",
+      "id": 7,
+      "pointee_type_id": null
+    }
+  ],
+  "functions": [
+    {
+      "returns": { "type_id": 4 },
+      "name": "give_greeting()",
+      "arguments": [],
+      "symbol": "give_greeting"
+    },
+    {
+      "returns": { "type_id": null },
+      "name": "jlw_free(p::Ptr{Nothing})",
+      "arguments": [
+        { "name": "p", "type_id": 7 }
+      ],
+      "symbol": "jlw_free"
+    },
+    {
+      "returns": { "type_id": null },
+      "name": "jlw_free_strings(p::Ptr{CString{:owned}}, n::Int64)",
+      "arguments": [
+        { "name": "p", "type_id": 5 },
+        { "name": "n", "type_id": 6 }
+      ],
+      "symbol": "jlw_free_strings"
+    }
+  ]
+}

--- a/JuliaLibWrapping/test/bindinginfo_cstring_owned_nofree.json
+++ b/JuliaLibWrapping/test/bindinginfo_cstring_owned_nofree.json
@@ -1,0 +1,69 @@
+{
+  "_comment": "Fixture identical to bindinginfo_cstring_owned.json EXCEPT the two jlw_free* release-entrypoint function entries are deleted (the `types` array \u2014 including the `Ptr{Nothing}` and `Ptr{CString{:owned}}` those functions used \u2014 is left untouched deliberately). This models a library that returns an owning `CString{:owned}` but forgot (or has not yet called) `JLWInterop.@export_release_entrypoints`. The generator must demote `give_greeting`, whose return would need `jlw_free`, to a mechanical re-export naming the macro to add. The owning class's `.free()` is still emitted but raises RuntimeError, for callers who bypass the facade and talk to `_lowlevel` directly.",
+  "types": [
+    {
+      "kind": "primitive",
+      "name": "UInt8",
+      "id": 1,
+      "size": 1,
+      "bits": 8,
+      "signed": false,
+      "alignment": 1
+    },
+    {
+      "kind": "primitive",
+      "name": "Int32",
+      "id": 2,
+      "size": 4,
+      "bits": 32,
+      "signed": true,
+      "alignment": 4
+    },
+    {
+      "kind": "pointer",
+      "name": "Ptr{UInt8}",
+      "id": 3,
+      "pointee_type_id": 1
+    },
+    {
+      "kind": "struct",
+      "name": "CString{:owned}",
+      "id": 4,
+      "size": 16,
+      "fields": [
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
+      ],
+      "alignment": 8
+    },
+    {
+      "kind": "pointer",
+      "name": "Ptr{CString{:owned}}",
+      "id": 5,
+      "pointee_type_id": 4
+    },
+    {
+      "kind": "primitive",
+      "name": "Int64",
+      "id": 6,
+      "size": 8,
+      "bits": 64,
+      "signed": true,
+      "alignment": 8
+    },
+    {
+      "kind": "pointer",
+      "name": "Ptr{Nothing}",
+      "id": 7,
+      "pointee_type_id": null
+    }
+  ],
+  "functions": [
+    {
+      "returns": { "type_id": 4 },
+      "name": "give_greeting()",
+      "arguments": [],
+      "symbol": "give_greeting"
+    }
+  ]
+}

--- a/JuliaLibWrapping/test/expected_carray3_facade.py
+++ b/JuliaLibWrapping/test/expected_carray3_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_carray_owned_facade.py
+++ b/JuliaLibWrapping/test/expected_carray_owned_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.
@@ -17,7 +17,7 @@ from . import _lowlevel  # noqa: F401
 import numpy as np  # noqa: F401
 
 from ._lowlevel import (
-    CString,
+    CString_owned,
     CVector_owned_Float64,
 )
 
@@ -29,4 +29,4 @@ def give_vec():
         _result.free()
     return _out
 
-__all__ = ["CString", "CVector_owned_Float64", "give_vec"]
+__all__ = ["CString_owned", "CVector_owned_Float64", "give_vec"]

--- a/JuliaLibWrapping/test/expected_carray_owned_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_carray_owned_lowlevel.py
@@ -54,34 +54,11 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     )
 _jlw_loaded.add(_jlw_this_pkg)
 
-class CString(ctypes.Structure):
+class CString_owned(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
-
-    @classmethod
-    def from_str(cls, s):
-        """Return a CString whose buffer holds the UTF-8 encoding of `s`.
-
-        Allocates a fresh ctypes buffer and copies the bytes into it; the
-        returned object holds a reference to that buffer, so the caller
-        must keep it alive for the duration of any C call that uses it."""
-        if not isinstance(s, str):
-            raise TypeError(f"expected str, got {type(s).__name__}")
-        return cls.from_bytes(s.encode("utf-8"))
-
-    @classmethod
-    def from_bytes(cls, b):
-        """Return a CString whose buffer holds a copy of the bytes `b`."""
-        if not isinstance(b, (bytes, bytearray)):
-            raise TypeError(f"expected bytes-like, got {type(b).__name__}")
-        n = len(b)
-        buf = (ctypes.c_uint8 * n).from_buffer_copy(b) if n else (ctypes.c_uint8 * 0)()
-        obj = cls(length=n,
-                  data=ctypes.cast(buf, ctypes.POINTER(ctypes.c_uint8)))
-        obj._buffer = buf
-        return obj
 
     def as_bytes(self):
         """Return a copy of the underlying bytes as a Python `bytes` object."""
@@ -90,6 +67,16 @@ class CString(ctypes.Structure):
     def as_str(self):
         """Return the underlying bytes decoded as UTF-8."""
         return self.as_bytes().decode("utf-8")
+
+    def free(self):
+        """Free the Julia-allocated buffer.
+
+        Idempotent: a second call is a no-op. For callers who bypass the
+        façade's convert-then-free wrapper and talk to `_lowlevel` directly."""
+        if getattr(self, "_freed", False):
+            return
+        _lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))
+        self._freed = True
 
 class CVector_owned_Float64(ctypes.Structure):
     _fields_ = [
@@ -119,6 +106,6 @@ def give_vec():
 _lib.jlw_free.argtypes = [ctypes.c_void_p]
 _lib.jlw_free.restype = None
 
-_lib.jlw_free_strings.argtypes = [ctypes.POINTER(CString), ctypes.c_int64]
+_lib.jlw_free_strings.argtypes = [ctypes.POINTER(CString_owned), ctypes.c_int64]
 _lib.jlw_free_strings.restype = None
 

--- a/JuliaLibWrapping/test/expected_carray_owned_nofree_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_carray_owned_nofree_lowlevel.py
@@ -54,34 +54,11 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     )
 _jlw_loaded.add(_jlw_this_pkg)
 
-class CString(ctypes.Structure):
+class CString_owned(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
-
-    @classmethod
-    def from_str(cls, s):
-        """Return a CString whose buffer holds the UTF-8 encoding of `s`.
-
-        Allocates a fresh ctypes buffer and copies the bytes into it; the
-        returned object holds a reference to that buffer, so the caller
-        must keep it alive for the duration of any C call that uses it."""
-        if not isinstance(s, str):
-            raise TypeError(f"expected str, got {type(s).__name__}")
-        return cls.from_bytes(s.encode("utf-8"))
-
-    @classmethod
-    def from_bytes(cls, b):
-        """Return a CString whose buffer holds a copy of the bytes `b`."""
-        if not isinstance(b, (bytes, bytearray)):
-            raise TypeError(f"expected bytes-like, got {type(b).__name__}")
-        n = len(b)
-        buf = (ctypes.c_uint8 * n).from_buffer_copy(b) if n else (ctypes.c_uint8 * 0)()
-        obj = cls(length=n,
-                  data=ctypes.cast(buf, ctypes.POINTER(ctypes.c_uint8)))
-        obj._buffer = buf
-        return obj
 
     def as_bytes(self):
         """Return a copy of the underlying bytes as a Python `bytes` object."""
@@ -90,6 +67,15 @@ class CString(ctypes.Structure):
     def as_str(self):
         """Return the underlying bytes decoded as UTF-8."""
         return self.as_bytes().decode("utf-8")
+
+    def free(self):
+        """Free the Julia-allocated buffer.
+
+        Idempotent: a second call is a no-op. For callers who bypass the
+        façade's convert-then-free wrapper and talk to `_lowlevel` directly."""
+        if getattr(self, "_freed", False):
+            return
+        raise RuntimeError("this library does not export release entrypoints; add JLWInterop.@export_release_entrypoints to the library")
 
 class CVector_owned_Float64(ctypes.Structure):
     _fields_ = [

--- a/JuliaLibWrapping/test/expected_cdict_facade.py
+++ b/JuliaLibWrapping/test/expected_cdict_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.
@@ -16,7 +16,8 @@ on every `write_wrapper` call.
 from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
-    CString,
+    CString_borrowed,
+    CString_owned,
     CDict_borrowed_Float64,
     CDict_owned_Float64,
 )
@@ -33,4 +34,4 @@ def give_dict():
         _result.free()
     return _out
 
-__all__ = ["CString", "CDict_borrowed_Float64", "CDict_owned_Float64", "take_dict", "give_dict"]
+__all__ = ["CString_borrowed", "CString_owned", "CDict_borrowed_Float64", "CDict_owned_Float64", "take_dict", "give_dict"]

--- a/JuliaLibWrapping/test/expected_cdict_int32_facade.py
+++ b/JuliaLibWrapping/test/expected_cdict_int32_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.
@@ -16,8 +16,9 @@ on every `write_wrapper` call.
 from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
-    CString,
+    CString_borrowed,
     CDict_borrowed_Int32,
+    CString_owned,
     CDict_owned_Int32,
 )
 
@@ -33,4 +34,4 @@ def give_dict_i32():
         _result.free()
     return _out
 
-__all__ = ["CString", "CDict_borrowed_Int32", "CDict_owned_Int32", "take_dict_i32", "give_dict_i32"]
+__all__ = ["CString_borrowed", "CDict_borrowed_Int32", "CString_owned", "CDict_owned_Int32", "take_dict_i32", "give_dict_i32"]

--- a/JuliaLibWrapping/test/expected_cdict_int32_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cdict_int32_lowlevel.py
@@ -53,7 +53,7 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     )
 _jlw_loaded.add(_jlw_this_pkg)
 
-class CString(ctypes.Structure):
+class CString_borrowed(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
@@ -93,18 +93,18 @@ class CString(ctypes.Structure):
 class CDict_borrowed_Int32(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int64),
-        ("keys", ctypes.POINTER(CString)),
+        ("keys", ctypes.POINTER(CString_borrowed)),
         ("values", ctypes.POINTER(ctypes.c_int32)),
     ]
 
     @classmethod
     def from_dict(cls, d):
         keys = [k.encode("utf-8") for k in d.keys()]
-        karr = (CString * len(keys))(
-            *[CString(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in keys])
+        karr = (CString_borrowed * len(keys))(
+            *[CString_borrowed(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in keys])
         varr = (ctypes.c_int32 * len(keys))(*d.values())
         obj = cls(length=len(keys),
-                  keys=ctypes.cast(karr, ctypes.POINTER(CString)),
+                  keys=ctypes.cast(karr, ctypes.POINTER(CString_borrowed)),
                   values=ctypes.cast(varr, ctypes.POINTER(ctypes.c_int32)))
         obj._buffer = (keys, karr, varr)
         return obj
@@ -117,10 +117,34 @@ class CDict_borrowed_Int32(ctypes.Structure):
             out[k] = self.values[i]
         return out
 
+class CString_owned(ctypes.Structure):
+    _fields_ = [
+        ("length", ctypes.c_int32),
+        ("data", ctypes.POINTER(ctypes.c_uint8)),
+    ]
+
+    def as_bytes(self):
+        """Return a copy of the underlying bytes as a Python `bytes` object."""
+        return ctypes.string_at(self.data, self.length)
+
+    def as_str(self):
+        """Return the underlying bytes decoded as UTF-8."""
+        return self.as_bytes().decode("utf-8")
+
+    def free(self):
+        """Free the Julia-allocated buffer.
+
+        Idempotent: a second call is a no-op. For callers who bypass the
+        façade's convert-then-free wrapper and talk to `_lowlevel` directly."""
+        if getattr(self, "_freed", False):
+            return
+        _lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))
+        self._freed = True
+
 class CDict_owned_Int32(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int64),
-        ("keys", ctypes.POINTER(CString)),
+        ("keys", ctypes.POINTER(CString_owned)),
         ("values", ctypes.POINTER(ctypes.c_int32)),
     ]
 
@@ -156,6 +180,6 @@ def give_dict_i32():
 _lib.jlw_free.argtypes = [ctypes.c_void_p]
 _lib.jlw_free.restype = None
 
-_lib.jlw_free_strings.argtypes = [ctypes.POINTER(CString), ctypes.c_int64]
+_lib.jlw_free_strings.argtypes = [ctypes.POINTER(CString_owned), ctypes.c_int64]
 _lib.jlw_free_strings.restype = None
 

--- a/JuliaLibWrapping/test/expected_cdict_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cdict_lowlevel.py
@@ -53,7 +53,7 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     )
 _jlw_loaded.add(_jlw_this_pkg)
 
-class CString(ctypes.Structure):
+class CString_borrowed(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
@@ -90,21 +90,45 @@ class CString(ctypes.Structure):
         """Return the underlying bytes decoded as UTF-8."""
         return self.as_bytes().decode("utf-8")
 
+class CString_owned(ctypes.Structure):
+    _fields_ = [
+        ("length", ctypes.c_int32),
+        ("data", ctypes.POINTER(ctypes.c_uint8)),
+    ]
+
+    def as_bytes(self):
+        """Return a copy of the underlying bytes as a Python `bytes` object."""
+        return ctypes.string_at(self.data, self.length)
+
+    def as_str(self):
+        """Return the underlying bytes decoded as UTF-8."""
+        return self.as_bytes().decode("utf-8")
+
+    def free(self):
+        """Free the Julia-allocated buffer.
+
+        Idempotent: a second call is a no-op. For callers who bypass the
+        façade's convert-then-free wrapper and talk to `_lowlevel` directly."""
+        if getattr(self, "_freed", False):
+            return
+        _lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))
+        self._freed = True
+
 class CDict_borrowed_Float64(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int64),
-        ("keys", ctypes.POINTER(CString)),
+        ("keys", ctypes.POINTER(CString_borrowed)),
         ("values", ctypes.POINTER(ctypes.c_double)),
     ]
 
     @classmethod
     def from_dict(cls, d):
         keys = [k.encode("utf-8") for k in d.keys()]
-        karr = (CString * len(keys))(
-            *[CString(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in keys])
+        karr = (CString_borrowed * len(keys))(
+            *[CString_borrowed(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in keys])
         varr = (ctypes.c_double * len(keys))(*d.values())
         obj = cls(length=len(keys),
-                  keys=ctypes.cast(karr, ctypes.POINTER(CString)),
+                  keys=ctypes.cast(karr, ctypes.POINTER(CString_borrowed)),
                   values=ctypes.cast(varr, ctypes.POINTER(ctypes.c_double)))
         obj._buffer = (keys, karr, varr)
         return obj
@@ -120,7 +144,7 @@ class CDict_borrowed_Float64(ctypes.Structure):
 class CDict_owned_Float64(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int64),
-        ("keys", ctypes.POINTER(CString)),
+        ("keys", ctypes.POINTER(CString_owned)),
         ("values", ctypes.POINTER(ctypes.c_double)),
     ]
 
@@ -156,6 +180,6 @@ def give_dict():
 _lib.jlw_free.argtypes = [ctypes.c_void_p]
 _lib.jlw_free.restype = None
 
-_lib.jlw_free_strings.argtypes = [ctypes.POINTER(CString), ctypes.c_int64]
+_lib.jlw_free_strings.argtypes = [ctypes.POINTER(CString_owned), ctypes.c_int64]
 _lib.jlw_free_strings.restype = None
 

--- a/JuliaLibWrapping/test/expected_cdict_nofree_facade.py
+++ b/JuliaLibWrapping/test/expected_cdict_nofree_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.
@@ -16,7 +16,8 @@ on every `write_wrapper` call.
 from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
-    CString,
+    CString_borrowed,
+    CString_owned,
     CDict_borrowed_Float64,
     CDict_owned_Float64,
 )
@@ -27,4 +28,4 @@ def take_dict(d):
     _d = CDict_borrowed_Float64.from_dict(d)
     return _lowlevel.take_dict(_d)
 
-__all__ = ["CString", "CDict_borrowed_Float64", "CDict_owned_Float64", "take_dict", "give_dict"]
+__all__ = ["CString_borrowed", "CString_owned", "CDict_borrowed_Float64", "CDict_owned_Float64", "take_dict", "give_dict"]

--- a/JuliaLibWrapping/test/expected_cdict_nofree_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cdict_nofree_lowlevel.py
@@ -53,7 +53,7 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     )
 _jlw_loaded.add(_jlw_this_pkg)
 
-class CString(ctypes.Structure):
+class CString_borrowed(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
@@ -90,21 +90,44 @@ class CString(ctypes.Structure):
         """Return the underlying bytes decoded as UTF-8."""
         return self.as_bytes().decode("utf-8")
 
+class CString_owned(ctypes.Structure):
+    _fields_ = [
+        ("length", ctypes.c_int32),
+        ("data", ctypes.POINTER(ctypes.c_uint8)),
+    ]
+
+    def as_bytes(self):
+        """Return a copy of the underlying bytes as a Python `bytes` object."""
+        return ctypes.string_at(self.data, self.length)
+
+    def as_str(self):
+        """Return the underlying bytes decoded as UTF-8."""
+        return self.as_bytes().decode("utf-8")
+
+    def free(self):
+        """Free the Julia-allocated buffer.
+
+        Idempotent: a second call is a no-op. For callers who bypass the
+        façade's convert-then-free wrapper and talk to `_lowlevel` directly."""
+        if getattr(self, "_freed", False):
+            return
+        raise RuntimeError("this library does not export release entrypoints; add JLWInterop.@export_release_entrypoints to the library")
+
 class CDict_borrowed_Float64(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int64),
-        ("keys", ctypes.POINTER(CString)),
+        ("keys", ctypes.POINTER(CString_borrowed)),
         ("values", ctypes.POINTER(ctypes.c_double)),
     ]
 
     @classmethod
     def from_dict(cls, d):
         keys = [k.encode("utf-8") for k in d.keys()]
-        karr = (CString * len(keys))(
-            *[CString(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in keys])
+        karr = (CString_borrowed * len(keys))(
+            *[CString_borrowed(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in keys])
         varr = (ctypes.c_double * len(keys))(*d.values())
         obj = cls(length=len(keys),
-                  keys=ctypes.cast(karr, ctypes.POINTER(CString)),
+                  keys=ctypes.cast(karr, ctypes.POINTER(CString_borrowed)),
                   values=ctypes.cast(varr, ctypes.POINTER(ctypes.c_double)))
         obj._buffer = (keys, karr, varr)
         return obj
@@ -120,7 +143,7 @@ class CDict_borrowed_Float64(ctypes.Structure):
 class CDict_owned_Float64(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int64),
-        ("keys", ctypes.POINTER(CString)),
+        ("keys", ctypes.POINTER(CString_owned)),
         ("values", ctypes.POINTER(ctypes.c_double)),
     ]
 

--- a/JuliaLibWrapping/test/expected_cmatrix_facade.py
+++ b/JuliaLibWrapping/test/expected_cmatrix_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_copt_facade.py
+++ b/JuliaLibWrapping/test/expected_copt_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_cstrarray_facade.py
+++ b/JuliaLibWrapping/test/expected_cstrarray_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.
@@ -16,8 +16,9 @@ on every `write_wrapper` call.
 from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
-    CString,
+    CString_borrowed,
     CStrArray_borrowed,
+    CString_owned,
     CStrArray_owned,
 )
 
@@ -33,4 +34,4 @@ def give_strs():
         _result.free()
     return _out
 
-__all__ = ["CString", "CStrArray_borrowed", "CStrArray_owned", "take_strs", "give_strs"]
+__all__ = ["CString_borrowed", "CStrArray_borrowed", "CString_owned", "CStrArray_owned", "take_strs", "give_strs"]

--- a/JuliaLibWrapping/test/expected_cstrarray_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cstrarray_lowlevel.py
@@ -53,7 +53,7 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     )
 _jlw_loaded.add(_jlw_this_pkg)
 
-class CString(ctypes.Structure):
+class CString_borrowed(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
@@ -93,7 +93,7 @@ class CString(ctypes.Structure):
 class CStrArray_borrowed(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int64),
-        ("data", ctypes.POINTER(CString)),
+        ("data", ctypes.POINTER(CString_borrowed)),
     ]
 
     @classmethod
@@ -101,9 +101,9 @@ class CStrArray_borrowed(ctypes.Structure):
         if not isinstance(items, (list, tuple)):
             raise TypeError("expected a list of str")
         bufs = [s.encode("utf-8") for s in items]
-        arr = (CString * len(bufs))(
-            *[CString(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in bufs])
-        obj = cls(length=len(bufs), data=ctypes.cast(arr, ctypes.POINTER(CString)))
+        arr = (CString_borrowed * len(bufs))(
+            *[CString_borrowed(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in bufs])
+        obj = cls(length=len(bufs), data=ctypes.cast(arr, ctypes.POINTER(CString_borrowed)))
         obj._buffer = (bufs, arr)   # keep buffers alive
         return obj
 
@@ -114,10 +114,34 @@ class CStrArray_borrowed(ctypes.Structure):
             out.append(ctypes.string_at(e.data, e.length).decode("utf-8"))
         return out
 
+class CString_owned(ctypes.Structure):
+    _fields_ = [
+        ("length", ctypes.c_int32),
+        ("data", ctypes.POINTER(ctypes.c_uint8)),
+    ]
+
+    def as_bytes(self):
+        """Return a copy of the underlying bytes as a Python `bytes` object."""
+        return ctypes.string_at(self.data, self.length)
+
+    def as_str(self):
+        """Return the underlying bytes decoded as UTF-8."""
+        return self.as_bytes().decode("utf-8")
+
+    def free(self):
+        """Free the Julia-allocated buffer.
+
+        Idempotent: a second call is a no-op. For callers who bypass the
+        façade's convert-then-free wrapper and talk to `_lowlevel` directly."""
+        if getattr(self, "_freed", False):
+            return
+        _lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))
+        self._freed = True
+
 class CStrArray_owned(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int64),
-        ("data", ctypes.POINTER(CString)),
+        ("data", ctypes.POINTER(CString_owned)),
     ]
 
     def as_list(self):
@@ -150,6 +174,6 @@ def give_strs():
 _lib.jlw_free.argtypes = [ctypes.c_void_p]
 _lib.jlw_free.restype = None
 
-_lib.jlw_free_strings.argtypes = [ctypes.POINTER(CString), ctypes.c_int64]
+_lib.jlw_free_strings.argtypes = [ctypes.POINTER(CString_owned), ctypes.c_int64]
 _lib.jlw_free_strings.restype = None
 

--- a/JuliaLibWrapping/test/expected_cstrarray_nofree_facade.py
+++ b/JuliaLibWrapping/test/expected_cstrarray_nofree_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.
@@ -16,8 +16,9 @@ on every `write_wrapper` call.
 from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
-    CString,
+    CString_borrowed,
     CStrArray_borrowed,
+    CString_owned,
     CStrArray_owned,
 )
 
@@ -27,4 +28,4 @@ def take_strs(a):
     _a = CStrArray_borrowed.from_list(a)
     return _lowlevel.take_strs(_a)
 
-__all__ = ["CString", "CStrArray_borrowed", "CStrArray_owned", "take_strs", "give_strs"]
+__all__ = ["CString_borrowed", "CStrArray_borrowed", "CString_owned", "CStrArray_owned", "take_strs", "give_strs"]

--- a/JuliaLibWrapping/test/expected_cstrarray_nofree_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cstrarray_nofree_lowlevel.py
@@ -53,7 +53,7 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     )
 _jlw_loaded.add(_jlw_this_pkg)
 
-class CString(ctypes.Structure):
+class CString_borrowed(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
@@ -93,7 +93,7 @@ class CString(ctypes.Structure):
 class CStrArray_borrowed(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int64),
-        ("data", ctypes.POINTER(CString)),
+        ("data", ctypes.POINTER(CString_borrowed)),
     ]
 
     @classmethod
@@ -101,9 +101,9 @@ class CStrArray_borrowed(ctypes.Structure):
         if not isinstance(items, (list, tuple)):
             raise TypeError("expected a list of str")
         bufs = [s.encode("utf-8") for s in items]
-        arr = (CString * len(bufs))(
-            *[CString(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in bufs])
-        obj = cls(length=len(bufs), data=ctypes.cast(arr, ctypes.POINTER(CString)))
+        arr = (CString_borrowed * len(bufs))(
+            *[CString_borrowed(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in bufs])
+        obj = cls(length=len(bufs), data=ctypes.cast(arr, ctypes.POINTER(CString_borrowed)))
         obj._buffer = (bufs, arr)   # keep buffers alive
         return obj
 
@@ -114,10 +114,33 @@ class CStrArray_borrowed(ctypes.Structure):
             out.append(ctypes.string_at(e.data, e.length).decode("utf-8"))
         return out
 
+class CString_owned(ctypes.Structure):
+    _fields_ = [
+        ("length", ctypes.c_int32),
+        ("data", ctypes.POINTER(ctypes.c_uint8)),
+    ]
+
+    def as_bytes(self):
+        """Return a copy of the underlying bytes as a Python `bytes` object."""
+        return ctypes.string_at(self.data, self.length)
+
+    def as_str(self):
+        """Return the underlying bytes decoded as UTF-8."""
+        return self.as_bytes().decode("utf-8")
+
+    def free(self):
+        """Free the Julia-allocated buffer.
+
+        Idempotent: a second call is a no-op. For callers who bypass the
+        façade's convert-then-free wrapper and talk to `_lowlevel` directly."""
+        if getattr(self, "_freed", False):
+            return
+        raise RuntimeError("this library does not export release entrypoints; add JLWInterop.@export_release_entrypoints to the library")
+
 class CStrArray_owned(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int64),
-        ("data", ctypes.POINTER(CString)),
+        ("data", ctypes.POINTER(CString_owned)),
     ]
 
     def as_list(self):

--- a/JuliaLibWrapping/test/expected_cstring_facade.py
+++ b/JuliaLibWrapping/test/expected_cstring_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.
@@ -16,15 +16,15 @@ on every `write_wrapper` call.
 from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
-    CString,
+    CString_borrowed,
 )
 
 def greeting_length(s):
-    _s = CString.from_str(s)
+    _s = CString_borrowed.from_str(s)
     return _lowlevel.greeting_length(_s)
 
 def greeting():
     _result = _lowlevel.greeting()
     return _result.as_str()
 
-__all__ = ["CString", "greeting_length", "greeting"]
+__all__ = ["CString_borrowed", "greeting_length", "greeting"]

--- a/JuliaLibWrapping/test/expected_cstring_owned_facade.py
+++ b/JuliaLibWrapping/test/expected_cstring_owned_facade.py
@@ -1,4 +1,4 @@
-"""carray_owned_nofree_demo idiomatic façade.
+"""cstring_owned_demo idiomatic façade.
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
@@ -17,9 +17,14 @@ from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
     CString_owned,
-    CVector_owned_Float64,
 )
 
-from ._lowlevel import give_vec  # TODO: hand-wrap — owning return needs release entrypoints; add JLWInterop.@export_release_entrypoints to the library
+def give_greeting():
+    _result = _lowlevel.give_greeting()
+    try:
+        _out = _result.as_str()
+    finally:
+        _result.free()
+    return _out
 
-__all__ = ["CString_owned", "CVector_owned_Float64", "give_vec"]
+__all__ = ["CString_owned", "give_greeting"]

--- a/JuliaLibWrapping/test/expected_cstring_owned_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cstring_owned_lowlevel.py
@@ -5,8 +5,8 @@ import sys
 import pathlib
 
 _HERE = pathlib.Path(__file__).resolve().parent
-_LIBRARY_BASENAME = "libcstring"
-_LIBRARY_ENV_VAR = "CSTRING_DEMO_LIBRARY"
+_LIBRARY_BASENAME = "libcstringowned"
+_LIBRARY_ENV_VAR = "CSTRING_OWNED_DEMO_LIBRARY"
 
 def _resolve_library_path():
     override = os.environ.get(_LIBRARY_ENV_VAR)
@@ -53,34 +53,11 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     )
 _jlw_loaded.add(_jlw_this_pkg)
 
-class CString_borrowed(ctypes.Structure):
+class CString_owned(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
-
-    @classmethod
-    def from_str(cls, s):
-        """Return a CString whose buffer holds the UTF-8 encoding of `s`.
-
-        Allocates a fresh ctypes buffer and copies the bytes into it; the
-        returned object holds a reference to that buffer, so the caller
-        must keep it alive for the duration of any C call that uses it."""
-        if not isinstance(s, str):
-            raise TypeError(f"expected str, got {type(s).__name__}")
-        return cls.from_bytes(s.encode("utf-8"))
-
-    @classmethod
-    def from_bytes(cls, b):
-        """Return a CString whose buffer holds a copy of the bytes `b`."""
-        if not isinstance(b, (bytes, bytearray)):
-            raise TypeError(f"expected bytes-like, got {type(b).__name__}")
-        n = len(b)
-        buf = (ctypes.c_uint8 * n).from_buffer_copy(b) if n else (ctypes.c_uint8 * 0)()
-        obj = cls(length=n,
-                  data=ctypes.cast(buf, ctypes.POINTER(ctypes.c_uint8)))
-        obj._buffer = buf
-        return obj
 
     def as_bytes(self):
         """Return a copy of the underlying bytes as a Python `bytes` object."""
@@ -90,13 +67,24 @@ class CString_borrowed(ctypes.Structure):
         """Return the underlying bytes decoded as UTF-8."""
         return self.as_bytes().decode("utf-8")
 
-_lib.greeting_length.argtypes = [CString_borrowed]
-_lib.greeting_length.restype = ctypes.c_int32
-def greeting_length(s):
-    return _lib.greeting_length(s)
+    def free(self):
+        """Free the Julia-allocated buffer.
 
-_lib.greeting.argtypes = []
-_lib.greeting.restype = CString_borrowed
-def greeting():
-    return _lib.greeting()
+        Idempotent: a second call is a no-op. For callers who bypass the
+        façade's convert-then-free wrapper and talk to `_lowlevel` directly."""
+        if getattr(self, "_freed", False):
+            return
+        _lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))
+        self._freed = True
+
+_lib.give_greeting.argtypes = []
+_lib.give_greeting.restype = CString_owned
+def give_greeting():
+    return _lib.give_greeting()
+
+_lib.jlw_free.argtypes = [ctypes.c_void_p]
+_lib.jlw_free.restype = None
+
+_lib.jlw_free_strings.argtypes = [ctypes.POINTER(CString_owned), ctypes.c_int64]
+_lib.jlw_free_strings.restype = None
 

--- a/JuliaLibWrapping/test/expected_cstring_owned_nofree_facade.py
+++ b/JuliaLibWrapping/test/expected_cstring_owned_nofree_facade.py
@@ -1,4 +1,4 @@
-"""carray_owned_nofree_demo idiomatic façade.
+"""cstring_owned_nofree_demo idiomatic façade.
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
@@ -17,9 +17,8 @@ from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
     CString_owned,
-    CVector_owned_Float64,
 )
 
-from ._lowlevel import give_vec  # TODO: hand-wrap — owning return needs release entrypoints; add JLWInterop.@export_release_entrypoints to the library
+from ._lowlevel import give_greeting  # TODO: hand-wrap — owning return needs release entrypoints; add JLWInterop.@export_release_entrypoints to the library
 
-__all__ = ["CString_owned", "CVector_owned_Float64", "give_vec"]
+__all__ = ["CString_owned", "give_greeting"]

--- a/JuliaLibWrapping/test/expected_cstring_owned_nofree_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cstring_owned_nofree_lowlevel.py
@@ -5,8 +5,8 @@ import sys
 import pathlib
 
 _HERE = pathlib.Path(__file__).resolve().parent
-_LIBRARY_BASENAME = "libcstring"
-_LIBRARY_ENV_VAR = "CSTRING_DEMO_LIBRARY"
+_LIBRARY_BASENAME = "libcstringownednofree"
+_LIBRARY_ENV_VAR = "CSTRING_OWNED_NOFREE_DEMO_LIBRARY"
 
 def _resolve_library_path():
     override = os.environ.get(_LIBRARY_ENV_VAR)
@@ -53,34 +53,11 @@ if _jlw_loaded and _jlw_this_pkg not in _jlw_loaded:
     )
 _jlw_loaded.add(_jlw_this_pkg)
 
-class CString_borrowed(ctypes.Structure):
+class CString_owned(ctypes.Structure):
     _fields_ = [
         ("length", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
-
-    @classmethod
-    def from_str(cls, s):
-        """Return a CString whose buffer holds the UTF-8 encoding of `s`.
-
-        Allocates a fresh ctypes buffer and copies the bytes into it; the
-        returned object holds a reference to that buffer, so the caller
-        must keep it alive for the duration of any C call that uses it."""
-        if not isinstance(s, str):
-            raise TypeError(f"expected str, got {type(s).__name__}")
-        return cls.from_bytes(s.encode("utf-8"))
-
-    @classmethod
-    def from_bytes(cls, b):
-        """Return a CString whose buffer holds a copy of the bytes `b`."""
-        if not isinstance(b, (bytes, bytearray)):
-            raise TypeError(f"expected bytes-like, got {type(b).__name__}")
-        n = len(b)
-        buf = (ctypes.c_uint8 * n).from_buffer_copy(b) if n else (ctypes.c_uint8 * 0)()
-        obj = cls(length=n,
-                  data=ctypes.cast(buf, ctypes.POINTER(ctypes.c_uint8)))
-        obj._buffer = buf
-        return obj
 
     def as_bytes(self):
         """Return a copy of the underlying bytes as a Python `bytes` object."""
@@ -90,13 +67,17 @@ class CString_borrowed(ctypes.Structure):
         """Return the underlying bytes decoded as UTF-8."""
         return self.as_bytes().decode("utf-8")
 
-_lib.greeting_length.argtypes = [CString_borrowed]
-_lib.greeting_length.restype = ctypes.c_int32
-def greeting_length(s):
-    return _lib.greeting_length(s)
+    def free(self):
+        """Free the Julia-allocated buffer.
 
-_lib.greeting.argtypes = []
-_lib.greeting.restype = CString_borrowed
-def greeting():
-    return _lib.greeting()
+        Idempotent: a second call is a no-op. For callers who bypass the
+        façade's convert-then-free wrapper and talk to `_lowlevel` directly."""
+        if getattr(self, "_freed", False):
+            return
+        raise RuntimeError("this library does not export release entrypoints; add JLWInterop.@export_release_entrypoints to the library")
+
+_lib.give_greeting.argtypes = []
+_lib.give_greeting.restype = CString_owned
+def give_greeting():
+    return _lib.give_greeting()
 

--- a/JuliaLibWrapping/test/expected_jlwstatus_facade.py
+++ b/JuliaLibWrapping/test/expected_jlwstatus_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_libsimple_facade.py
+++ b/JuliaLibWrapping/test/expected_libsimple_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/expected_rawptr_facade.py
+++ b/JuliaLibWrapping/test/expected_rawptr_facade.py
@@ -2,7 +2,7 @@
 
 This file is generated **once** by JuliaLibWrapping as a starter
 façade. Functions whose arguments and return are all recognized
-(primitives, `CArray{owned,T,N}`, `CString`, direct `JLWStatus`)
+(primitives, `CArray{owned,T,N}`, `CString{owned}`, direct `JLWStatus`)
 are wrapped to accept and return idiomatic Python objects (numpy
 arrays, `str`). Anything else is re-exported from `_lowlevel`
 with a `TODO` comment naming what needs hand-wrapping.

--- a/JuliaLibWrapping/test/runtests.jl
+++ b/JuliaLibWrapping/test/runtests.jl
@@ -16,6 +16,16 @@ function onlymatch(f, collection)
     return matches[1]
 end
 
+# The body of one emitted `ctypes.Structure` class, up to the next class.
+function classbody(bindings::AbstractString, name::AbstractString)
+    header = "class " * name * "(ctypes.Structure):"
+    range = findfirst(header, bindings)
+    isnothing(range) && error("no class named `", name, "` in the emitted bindings")
+    rest = SubString(bindings, last(range) + 1)
+    stop = findfirst("\nclass ", rest)
+    return isnothing(stop) ? rest : SubString(rest, 1, first(stop) - 1)
+end
+
 @testset "JuliaLibWrapping.jl" begin
     @testset "parse_abi_info" begin
         abi_info = parse_abi_info(parsefile("bindinginfo_libsimple.json"))
@@ -287,6 +297,20 @@ end
             @test occursin("float copyto_and_sum(CVectorPair_Float32 fromto);", content)
             @test occursin("int32_t countsame(MyTwoVec* list, int32_t n);", content)
         end
+
+        # The two CString ownerships are two distinct C typedefs, so whether a
+        # buffer must be freed is visible in the signature.
+        mktempdir() do path
+            dest = CTarget(path, "libcstrarray")
+            write_wrapper(dest, read_abi_info("bindinginfo_cstrarray.json"))
+
+            content = read(joinpath(dest.dir, dest.headerbase * ".h"), String)
+            @test occursin("typedef struct CString_borrowed {", content)
+            @test occursin("typedef struct CString_owned {", content)
+            @test occursin("    CString_borrowed* data;", content)
+            @test occursin("    CString_owned* data;", content)
+            @test occursin("void jlw_free_strings(CString_owned* p, int64_t n);", content)
+        end
     end
 
     @testset "mangle_c!" begin
@@ -320,6 +344,16 @@ end
         @test mangle_c!(typedict, 1, typeinfo) == "Foo"
         @test mangle_c!(typedict, 2, typeinfo) == "Foo_3"
         @test mangle_c!(typedict, 3, typeinfo) == "Foo_4"
+
+        # Ownership parameters sanitize to distinct, valid C identifiers
+        # rather than colliding on a shared prefix.
+        typedict = Dict{Int, String}()
+        typeinfo = OrderedDict{Int, TypeDesc}(
+            1 => StructDesc("CString{:borrowed}", 16, 8, FieldDesc[]),
+            2 => StructDesc("CString{:owned}", 16, 8, FieldDesc[]),
+        )
+        @test mangle_c!(typedict, 1, typeinfo) == "CString_borrowed"
+        @test mangle_c!(typedict, 2, typeinfo) == "CString_owned"
     end
 
     @testset "PythonTarget" begin
@@ -745,15 +779,18 @@ end
     end
 
     @testset "cstring_struct_info" begin
-        # Recognize the CString layout structurally.
+        # Recognition requires an ownership parameter and the CString layout.
         csinfo = JuliaLibWrapping.cstring_struct_info
-        abi = read_abi_info("bindinginfo_cstring.json")
         findtype(descs, name) = (
             k = collect(keys(descs));
             k[findfirst((id) -> descs[id].name === name, k)]
         )
-        cs = abi.typeinfo[findtype(abi.typeinfo, "CString")]
-        @test csinfo(cs, abi.typeinfo) === true
+        abi = read_abi_info("bindinginfo_cstring.json")
+        cs = abi.typeinfo[findtype(abi.typeinfo, "CString{:borrowed}")]
+        @test csinfo(cs, abi.typeinfo).ownership === :borrowed
+        abi_owned = read_abi_info("bindinginfo_cstring_owned.json")
+        cs_owned = abi_owned.typeinfo[findtype(abi_owned.typeinfo, "CString{:owned}")]
+        @test csinfo(cs_owned, abi_owned.typeinfo).ownership === :owned
 
         # Hand-built rejections.
         primint = PrimitiveTypeDesc("Int32", true, 32, 4, 4)
@@ -765,43 +802,57 @@ end
             1 => primint, 2 => primu8, 3 => primu16,
             4 => ptr_to_u8, 5 => ptr_to_u16,
             6 => StructDesc(
-                "CString", 16, 8, FieldDesc[
+                "CString{:borrowed}", 16, 8, FieldDesc[
                     FieldDesc("length", 1, 0),
                     FieldDesc("data", 4, 8),
                 ]
             ),
             7 => StructDesc(
-                "NotACString", 16, 8, FieldDesc[
+                "NotACString{:borrowed}", 16, 8, FieldDesc[
                     FieldDesc("length", 1, 0),
                     FieldDesc("data", 4, 8),
                 ]
             ),
             8 => StructDesc(
-                "CStringU16", 16, 8, FieldDesc[
+                "CString{:borrowed}", 16, 8, FieldDesc[
                     FieldDesc("length", 1, 0),
                     FieldDesc("data", 5, 8),  # Ptr{UInt16} — not UInt8
                 ]
             ),
             9 => StructDesc(
-                "CStringBadNames", 16, 8, FieldDesc[
+                "CString{:borrowed}", 16, 8, FieldDesc[
                     FieldDesc("size", 1, 0),
                     FieldDesc("data", 4, 8),
                 ]
             ),
+            10 => StructDesc(
+                "CString", 16, 8, FieldDesc[   # no ownership token
+                    FieldDesc("length", 1, 0),
+                    FieldDesc("data", 4, 8),
+                ]
+            ),
+            11 => StructDesc(
+                "CString{:owned}", 16, 8, FieldDesc[
+                    FieldDesc("length", 1, 0),
+                    FieldDesc("data", 4, 8),
+                ]
+            ),
         )
-        @test csinfo(ti[6], ti) === true
-        @test csinfo(ti[7], ti) === false  # wrong name prefix
-        @test csinfo(ti[8], ti) === false  # non-UInt8 pointee
-        @test csinfo(ti[9], ti) === false  # wrong field names
+        @test csinfo(ti[6], ti).ownership === :borrowed
+        @test isnothing(csinfo(ti[7], ti))  # wrong name prefix
+        @test isnothing(csinfo(ti[8], ti))  # non-UInt8 pointee
+        @test isnothing(csinfo(ti[9], ti))  # wrong field names
+        @test isnothing(csinfo(ti[10], ti)) # name states no ownership
+        @test csinfo(ti[11], ti).ownership === :owned
 
         # Field order may be either way.
         flipped = StructDesc(
-            "CString", 16, 8, FieldDesc[
+            "CString{:owned}", 16, 8, FieldDesc[
                 FieldDesc("data", 4, 0),
                 FieldDesc("length", 1, 8),
             ]
         )
-        @test csinfo(flipped, ti) === true
+        @test csinfo(flipped, ti).ownership === :owned
     end
 
     @testset "cstrarray_struct_info" begin
@@ -826,7 +877,7 @@ end
         ptr_to_u8 = PointerDesc("Ptr{UInt8}", 4)
         ptr_to_u16 = PointerDesc("Ptr{UInt16}", 5)
         cstring_ok = StructDesc(
-            "CString", 16, 8, FieldDesc[
+            "CString{:borrowed}", 16, 8, FieldDesc[
                 FieldDesc("length", 1, 0),
                 FieldDesc("data", 6, 8),
             ]
@@ -834,19 +885,26 @@ end
         cstring_bad = StructDesc(
             # `data` points to UInt16, not UInt8 — `cstring_struct_info`
             # rejects this, so it must not be accepted as a CString pointee.
-            "NotCString", 16, 8, FieldDesc[
+            "CString{:borrowed}", 16, 8, FieldDesc[
                 FieldDesc("length", 1, 0),
                 FieldDesc("data", 7, 8),
             ]
         )
-        ptr_to_cstring = PointerDesc("Ptr{CString}", 8)
-        ptr_to_not_cstring = PointerDesc("Ptr{NotCString}", 9)
+        cstring_owned = StructDesc(
+            "CString{:owned}", 16, 8, FieldDesc[
+                FieldDesc("length", 1, 0),
+                FieldDesc("data", 6, 8),
+            ]
+        )
+        ptr_to_cstring = PointerDesc("Ptr{CString{:borrowed}}", 8)
+        ptr_to_bad_cstring = PointerDesc("Ptr{CString{:borrowed}}", 9)
+        ptr_to_cstring_owned = PointerDesc("Ptr{CString{:owned}}", 21)
         ti = OrderedDict{Int, TypeDesc}(
             1 => primi32, 2 => primi64, 3 => primu64,
             4 => primu8, 5 => primu16,
             6 => ptr_to_u8, 7 => ptr_to_u16,
             8 => cstring_ok, 9 => cstring_bad,
-            10 => ptr_to_cstring, 11 => ptr_to_not_cstring,
+            10 => ptr_to_cstring, 11 => ptr_to_bad_cstring,
             12 => StructDesc(
                 "CStrArray{:borrowed}", 16, 8, FieldDesc[
                     FieldDesc("length", 2, 0),
@@ -899,7 +957,20 @@ end
             20 => StructDesc(
                 "CStrArray{:owned}", 16, 8, FieldDesc[
                     FieldDesc("length", 2, 0),
-                    FieldDesc("data", 10, 8),
+                    FieldDesc("data", 22, 8),
+                ]
+            ),
+            21 => cstring_owned, 22 => ptr_to_cstring_owned,
+            23 => StructDesc(
+                "CStrArray{:owned}", 16, 8, FieldDesc[
+                    FieldDesc("length", 2, 0),
+                    FieldDesc("data", 10, 8),  # borrowed elements in an owning container
+                ]
+            ),
+            24 => StructDesc(
+                "CStrArray{:borrowed}", 16, 8, FieldDesc[
+                    FieldDesc("length", 2, 0),
+                    FieldDesc("data", 22, 8),  # owned elements in a borrowed container
                 ]
             ),
         )
@@ -912,11 +983,13 @@ end
         @test isnothing(csainfo(ti[18], ti))  # name states no ownership
         @test isnothing(csainfo(ti[19], ti))  # three-field layout rejected
         @test csainfo(ti[20], ti).ownership === :owned
+        @test isnothing(csainfo(ti[23], ti))  # element ownership must match the container's
+        @test isnothing(csainfo(ti[24], ti))  # ...in either direction
 
         # Field order may be either way.
         flipped = StructDesc(
             "CStrArray{:owned}", 16, 8, FieldDesc[
-                FieldDesc("data", 10, 8),
+                FieldDesc("data", 22, 8),
                 FieldDesc("length", 2, 0),
             ]
         )
@@ -958,7 +1031,7 @@ end
         ptr_to_f64 = PointerDesc("Ptr{Float64}", 5)
         ptr_to_notreal = PointerDesc("Ptr{NotARealType}", 6)
         cstring_ok = StructDesc(
-            "CString", 16, 8, FieldDesc[
+            "CString{:borrowed}", 16, 8, FieldDesc[
                 FieldDesc("length", 1, 0),
                 FieldDesc("data", 7, 8),
             ]
@@ -966,20 +1039,27 @@ end
         cstring_bad = StructDesc(
             # `data` points to UInt16, not UInt8 — `cstring_struct_info`
             # rejects this, so it must not be accepted as a CString pointee.
-            "NotCString", 16, 8, FieldDesc[
+            "CString{:borrowed}", 16, 8, FieldDesc[
                 FieldDesc("length", 1, 0),
                 FieldDesc("data", 8, 8),
             ]
         )
-        ptr_to_cstring = PointerDesc("Ptr{CString}", 9)
-        ptr_to_not_cstring = PointerDesc("Ptr{NotCString}", 10)
+        cstring_owned = StructDesc(
+            "CString{:owned}", 16, 8, FieldDesc[
+                FieldDesc("length", 1, 0),
+                FieldDesc("data", 7, 8),
+            ]
+        )
+        ptr_to_cstring = PointerDesc("Ptr{CString{:borrowed}}", 9)
+        ptr_to_bad_cstring = PointerDesc("Ptr{CString{:borrowed}}", 10)
+        ptr_to_cstring_owned = PointerDesc("Ptr{CString{:owned}}", 28)
         ti = OrderedDict{Int, TypeDesc}(
             1 => primi32, 2 => primi64,
             3 => primu8, 4 => primu16, 5 => primf64,
             6 => primnotreal,
             7 => ptr_to_u8, 8 => ptr_to_u16,
             9 => cstring_ok, 10 => cstring_bad,
-            11 => ptr_to_cstring, 12 => ptr_to_not_cstring,
+            11 => ptr_to_cstring, 12 => ptr_to_bad_cstring,
             13 => ptr_to_f64, 14 => ptr_to_notreal,
             15 => StructDesc(
                 "CDict{:borrowed, Float64}", 24, 8, FieldDesc[
@@ -1059,7 +1139,22 @@ end
             27 => StructDesc(
                 "CDict{:owned, Float64}", 24, 8, FieldDesc[
                     FieldDesc("length", 2, 0),
-                    FieldDesc("keys", 11, 8),
+                    FieldDesc("keys", 29, 8),
+                    FieldDesc("values", 13, 16),
+                ]
+            ),
+            28 => cstring_owned, 29 => ptr_to_cstring_owned,
+            30 => StructDesc(
+                "CDict{:owned, Float64}", 24, 8, FieldDesc[
+                    FieldDesc("length", 2, 0),
+                    FieldDesc("keys", 11, 8),  # borrowed keys in an owning dictionary
+                    FieldDesc("values", 13, 16),
+                ]
+            ),
+            31 => StructDesc(
+                "CDict{:borrowed, Float64}", 24, 8, FieldDesc[
+                    FieldDesc("length", 2, 0),
+                    FieldDesc("keys", 29, 8),  # owned keys in a borrowed dictionary
                     FieldDesc("values", 13, 16),
                 ]
             ),
@@ -1079,13 +1174,15 @@ end
         @test cdinfo(ti[26], ti).value_type == "Cvoid"
         @test isnothing(pycdinfo(ti[26], ti)) # ...but Cvoid is not a scalar payload type
         @test cdinfo(ti[27], ti).ownership === :owned
+        @test isnothing(cdinfo(ti[30], ti)) # key ownership must match the dictionary's
+        @test isnothing(cdinfo(ti[31], ti)) # ...in either direction
 
         # Field order may be any permutation.
         permuted = StructDesc(
             "CDict{:owned, Float64}", 24, 8, FieldDesc[
                 FieldDesc("values", 13, 16),
                 FieldDesc("length", 2, 0),
-                FieldDesc("keys", 11, 8),
+                FieldDesc("keys", 29, 8),
             ]
         )
         @test cdinfo(permuted, ti).ownership === :owned
@@ -1235,7 +1332,7 @@ end
     end
 
     @testset "CString vocabulary" begin
-        # CString conversion does not require numpy.
+        # Borrowed CString conversion requires no numpy or release function.
         abi = read_abi_info("bindinginfo_cstring.json")
         mktempdir() do path
             dest = PythonTarget(path, "cstring_demo", "libcstring")
@@ -1249,8 +1346,8 @@ end
             pyproject = read(joinpath(path, "pyproject.toml"), String)
             @test !occursin("numpy", pyproject)
 
-            # Struct + helpers.
-            @test occursin("class CString(ctypes.Structure):", bindings)
+            # Borrowed classes construct values but do not release them.
+            @test occursin("class CString_borrowed(ctypes.Structure):", bindings)
             @test occursin("(\"length\", ctypes.c_int32)", bindings)
             @test occursin("(\"data\", ctypes.POINTER(ctypes.c_uint8))", bindings)
             @test occursin("def from_str(cls, s):", bindings)
@@ -1260,10 +1357,11 @@ end
             @test occursin("s.encode(\"utf-8\")", bindings)
             @test occursin("ctypes.string_at(self.data, self.length)", bindings)
             @test occursin(".decode(\"utf-8\")", bindings)
+            @test !occursin("def free(self):", bindings)
 
             # Round-trip-direction entrypoints are emitted as bare bindings.
-            @test occursin("_lib.greeting_length.argtypes = [CString]", bindings)
-            @test occursin("_lib.greeting.restype = CString", bindings)
+            @test occursin("_lib.greeting_length.argtypes = [CString_borrowed]", bindings)
+            @test occursin("_lib.greeting.restype = CString_borrowed", bindings)
 
             golden = read(joinpath(@__DIR__, "expected_cstring_lowlevel.py"), String)
             @test bindings == golden
@@ -1271,18 +1369,112 @@ end
             # Façade auto-wrap: CString args/returns become str in/out.
             facade = read(joinpath(path, "cstring_demo", "_facade.py"), String)
             @test occursin(
-                "def greeting_length(s):\n    _s = CString.from_str(s)\n" *
+                "def greeting_length(s):\n    _s = CString_borrowed.from_str(s)\n" *
                     "    return _lowlevel.greeting_length(_s)", facade
             )
             @test occursin(
                 "def greeting():\n    _result = _lowlevel.greeting()\n" *
                     "    return _result.as_str()", facade
             )
+            @test !occursin("_result.free()", facade)
             golden_facade = read(joinpath(@__DIR__, "expected_cstring_facade.py"), String)
             @test facade == golden_facade
 
             python3 = Sys.which("python3")
             if python3 !== nothing
+                cmd = `$python3 -c "import ast; ast.parse(open('$bindings_path').read())"`
+                @test success(run(pipeline(cmd; stderr = devnull, stdout = devnull); wait = true))
+            elseif haskey(ENV, "CI")
+                error("python3 not found on PATH; required on CI to validate the emitted wrapper")
+            end
+        end
+    end
+
+    @testset "CString owned-return vocabulary" begin
+        # The consumer releases an owning return with `jlw_free`.
+        abi = read_abi_info("bindinginfo_cstring_owned.json")
+        mktempdir() do path
+            dest = PythonTarget(path, "cstring_owned_demo", "libcstringowned")
+            write_wrapper(dest, abi)
+
+            bindings_path = joinpath(path, "cstring_owned_demo", "_lowlevel.py")
+            bindings = read(bindings_path, String)
+
+            # Owning classes have an idempotent `free()` but no constructors.
+            @test occursin("class CString_owned(ctypes.Structure):", bindings)
+            @test !occursin("def from_str(cls, s):", bindings)
+            @test !occursin("def from_bytes(cls, b):", bindings)
+            @test occursin("def as_bytes(self):", bindings)
+            @test occursin("def as_str(self):", bindings)
+            @test occursin("        if getattr(self, \"_freed\", False):\n            return", bindings)
+            @test occursin("_lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))", bindings)
+            @test occursin("        self._freed = True", bindings)
+
+            golden = read(joinpath(@__DIR__, "expected_cstring_owned_lowlevel.py"), String)
+            @test bindings == golden
+
+            # Façade auto-wrap: decode to `str` first, then free in `finally`.
+            facade = read(joinpath(path, "cstring_owned_demo", "_facade.py"), String)
+            @test occursin(
+                "def give_greeting():\n    _result = _lowlevel.give_greeting()\n" *
+                    "    try:\n        _out = _result.as_str()\n" *
+                    "    finally:\n        _result.free()\n    return _out",
+                facade
+            )
+            @test !occursin("_lowlevel._lib.jlw_free", facade)
+            golden_facade = read(joinpath(@__DIR__, "expected_cstring_owned_facade.py"), String)
+            @test facade == golden_facade
+
+            python3 = Sys.which("python3")
+            if !isnothing(python3)
+                cmd = `$python3 -c "import ast; ast.parse(open('$bindings_path').read())"`
+                @test success(run(pipeline(cmd; stderr = devnull, stdout = devnull); wait = true))
+                facade_path = joinpath(path, "cstring_owned_demo", "_facade.py")
+                cmd_f = `$python3 -c "import ast; ast.parse(open('$facade_path').read())"`
+                @test success(run(pipeline(cmd_f; stderr = devnull, stdout = devnull); wait = true))
+            elseif haskey(ENV, "CI")
+                error("python3 not found on PATH; required on CI to validate the emitted wrapper")
+            end
+        end
+    end
+
+    @testset "CString owning return without release symbols" begin
+        # Same gate as CArray/CStrArray/CDict: an owning return with no
+        # release entrypoints falls back to a mechanical TODO naming the macro
+        # to add, rather than emitting a call to an absent symbol.
+        abi = read_abi_info("bindinginfo_cstring_owned_nofree.json")
+        @test JuliaLibWrapping._release_symbols_present(abi) === false
+        mktempdir() do path
+            dest = PythonTarget(path, "cstring_owned_nofree_demo", "libcstringownednofree")
+            write_wrapper(dest, abi)
+
+            bindings_path = joinpath(path, "cstring_owned_nofree_demo", "_lowlevel.py")
+            bindings = read(bindings_path, String)
+            @test !occursin("_lib.jlw_free.argtypes", bindings)
+            @test occursin("def free(self):", bindings)
+            @test !occursin("_lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))", bindings)
+            @test occursin(
+                "raise RuntimeError(\"this library does not export release entrypoints; " *
+                    "add JLWInterop.@export_release_entrypoints to the library\")",
+                bindings
+            )
+
+            golden = read(joinpath(@__DIR__, "expected_cstring_owned_nofree_lowlevel.py"), String)
+            @test bindings == golden
+
+            facade = read(joinpath(path, "cstring_owned_nofree_demo", "_facade.py"), String)
+            @test !occursin("def give_greeting():", facade)
+            @test occursin(
+                "from ._lowlevel import give_greeting  # TODO: hand-wrap — " *
+                    "owning return needs release entrypoints; add " *
+                    "JLWInterop.@export_release_entrypoints to the library",
+                facade
+            )
+            golden_facade = read(joinpath(@__DIR__, "expected_cstring_owned_nofree_facade.py"), String)
+            @test facade == golden_facade
+
+            python3 = Sys.which("python3")
+            if !isnothing(python3)
                 cmd = `$python3 -c "import ast; ast.parse(open('$bindings_path').read())"`
                 @test success(run(pipeline(cmd; stderr = devnull, stdout = devnull); wait = true))
             elseif haskey(ENV, "CI")
@@ -1332,9 +1524,8 @@ end
             @test !occursin("(\"owned\", ctypes.c_int32)", bindings)
             @test occursin("class CStrArray_borrowed(ctypes.Structure):", bindings)
             @test occursin("class CStrArray_owned(ctypes.Structure):", bindings)
-            borrowed_body, owned_body = split(
-                bindings, "class CStrArray_owned(ctypes.Structure):"
-            )
+            borrowed_body = classbody(bindings, "CStrArray_borrowed")
+            owned_body = classbody(bindings, "CStrArray_owned")
             @test occursin("def from_list(cls, items):", borrowed_body)
             @test !occursin("def free(self):", borrowed_body)
             @test !occursin("def from_list(cls, items):", owned_body)
@@ -1418,9 +1609,8 @@ end
             @test !occursin("(\"owned\", ctypes.c_int32)", bindings)
             @test occursin("class CDict_borrowed_Float64(ctypes.Structure):", bindings)
             @test occursin("class CDict_owned_Float64(ctypes.Structure):", bindings)
-            borrowed_body, owned_body = split(
-                bindings, "class CDict_owned_Float64(ctypes.Structure):"
-            )
+            borrowed_body = classbody(bindings, "CDict_borrowed_Float64")
+            owned_body = classbody(bindings, "CDict_owned_Float64")
             @test occursin("def from_dict(cls, d):", borrowed_body)
             @test !occursin("def free(self):", borrowed_body)
             @test !occursin("def from_dict(cls, d):", owned_body)
@@ -1480,8 +1670,13 @@ end
             @test occursin("class CDict_borrowed_Int32(ctypes.Structure):", bindings)
             @test occursin("class CDict_owned_Int32(ctypes.Structure):", bindings)
             @test occursin("(\"length\", ctypes.c_int64)", bindings)
+            # Keys carry the dictionary's ownership, so the two dictionaries
+            # point at two distinct CString classes.
             @test occursin(
-                "(\"keys\", ctypes.POINTER(CString))", bindings
+                "(\"keys\", ctypes.POINTER(CString_borrowed))", bindings
+            )
+            @test occursin(
+                "(\"keys\", ctypes.POINTER(CString_owned))", bindings
             )
             @test occursin("(\"values\", ctypes.POINTER(ctypes.c_int32))", bindings)
             # The value ctype substitution varies: Int32 here, not Float64.
@@ -2000,6 +2195,52 @@ end
         cls = classify_arg(arg_o, owned.typeinfo, td_o)
         @test cls.kind === :opaque
         @test cls.reason == "argument transfers CArray ownership into the library; hand-wrap"
+    end
+
+    @testset "CString façade classification by ownership" begin
+        # CString follows the CArray ownership rules.
+        classify_arg = JuliaLibWrapping._facade_classify_arg
+        classify_ret = JuliaLibWrapping._facade_classify_return
+        findtype(descs, name) = (
+            k = collect(keys(descs));
+            k[findfirst((id) -> descs[id].name === name, k)]
+        )
+        premangled(abi) = (
+            d = Dict{Int, String}();
+            for (id, type) in pairs(abi.typeinfo)
+                type isa StructDesc && JuliaLibWrapping.mangle_python!(d, id, abi.typeinfo)
+            end;
+            d
+        )
+
+        borrowed = read_abi_info("bindinginfo_cstring.json")
+        td_b = premangled(borrowed)
+        cs_id = findtype(borrowed.typeinfo, "CString{:borrowed}")
+
+        # A borrowed argument arrives as a Python `str`.
+        arg_b = JuliaLibWrapping.ArgDesc("s", cs_id, false)
+        @test classify_arg(arg_b, borrowed.typeinfo, td_b).kind === :cstring
+
+        # A borrowed return needs no release entrypoint.
+        m_borrowed = onlymatch(md -> md.symbol == "greeting", borrowed.entrypoints)
+        @test classify_ret(m_borrowed, borrowed.typeinfo, td_b, false).kind === :cstring_convert
+
+        owned = read_abi_info("bindinginfo_cstring_owned.json")
+        td_o = premangled(owned)
+        cso_id = findtype(owned.typeinfo, "CString{:owned}")
+        m_owned = onlymatch(md -> md.symbol == "give_greeting", owned.entrypoints)
+
+        # An owning return requires release entrypoints.
+        @test classify_ret(m_owned, owned.typeinfo, td_o, true).kind === :cstring_unwrap
+        demoted = classify_ret(m_owned, owned.typeinfo, td_o, false)
+        @test demoted.kind === :opaque
+        @test occursin("owning return needs release entrypoints", demoted.reason)
+
+        # Owning arguments require a manual wrapper.
+        arg_o = JuliaLibWrapping.ArgDesc("s", cso_id, false)
+        cls = classify_arg(arg_o, owned.typeinfo, td_o)
+        @test cls.kind === :opaque
+        @test cls.reason == "argument transfers CString ownership into the library; hand-wrap"
     end
 
     @testset "raw primitive pointer docstring" begin


### PR DESCRIPTION
Require an explicit :owned or :borrowed parameter and propagate it to string arrays and dictionary keys. Generate Python wrappers that construct borrowed strings and release owning returns.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>

CC @el-oso this is probably the last thing we need to address before rebasing #74