### PR TITLE
Use Int64 for carrier lengths and dimensions

### DIFF
--- a/JLWInterop/src/JLWInterop.jl
+++ b/JLWInterop/src/JLWInterop.jl
@@ -71,7 +71,7 @@ semantics. The two ownerships are two distinct types, so a target reads
 "release this" or "do not release this" off the signature alone.
 """
 struct CArray{owned, T, N} <: AbstractArray{T, N}
-    dims::NTuple{N, Int32}
+    dims::NTuple{N, Int64}
     data::Ptr{T}
 
     function CArray{owned, T, N}(dims, data) where {owned, T, N}
@@ -150,15 +150,12 @@ b = CArray{:borrowed}(buf)  # aliases buf; keep buf alive while b is in use
 """
 function CArray{owned}(A::AbstractArray{T, N}) where {owned, T, N}
     if owned === :owned
-        # `dims` is `NTuple{N,Int32}` but `size` gives `Int`s, so this can
-        # throw. Narrow before the `malloc`: nothing would free that buffer.
-        dims = convert(NTuple{N, Int32}, size(A))
         dense = Array{T, N}(undef, size(A))
         copyto!(dense, A)
         n = length(dense)
         data = Ptr{T}(Libc.malloc(max(n, 1) * sizeof(T)))
         GC.@preserve dense unsafe_copyto!(data, pointer(dense), n)
-        return CArray{owned, T, N}(dims, data)
+        return CArray{owned, T, N}(size(A), data)
     elseif owned === :borrowed
         throw(
             ArgumentError(
@@ -239,7 +236,7 @@ rejected.
 Julia `String`.
 """
 struct CString{owned} <: AbstractString
-    length::Int32
+    length::Int64
     data::Ptr{UInt8}
 
     function CString{owned}(length, data) where {owned}
@@ -256,12 +253,9 @@ end
 function CString{:owned}(s::AbstractString)
     str = String(s)
     nb = sizeof(str)
-    # `length` is `Int32` but `sizeof` gives an `Int`, so this can throw.
-    # Narrow before the `malloc`: nothing would free that buffer.
-    len = Int32(nb)
     p = Ptr{UInt8}(Libc.malloc(max(nb, 1)))  # never malloc(0): an empty string still needs a non-NULL, freeable p
     GC.@preserve str unsafe_copyto!(p, pointer(str), nb)
-    return CString{:owned}(len, p)
+    return CString{:owned}(Int64(nb), p)
 end
 
 Base.ncodeunits(s::CString) = Int(s.length)

--- a/JLWInterop/src/result.jl
+++ b/JLWInterop/src/result.jl
@@ -43,11 +43,11 @@ function _zero_carrier(::Type{C}) where {C}
 end
 
 _zero_carrier(::Type{T}) where {T <: Union{Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64, Bool}} = zero(T)
-_zero_carrier(::Type{CString{owned}}) where {owned} = CString{owned}(Int32(0), Ptr{UInt8}(C_NULL))
+_zero_carrier(::Type{CString{owned}}) where {owned} = CString{owned}(Int64(0), Ptr{UInt8}(C_NULL))
 _zero_carrier(::Type{CStrArray{owned}}) where {owned} =
     CStrArray{owned}(Int64(0), Ptr{CString{owned}}(C_NULL))
 _zero_carrier(::Type{CDict{owned, V}}) where {owned, V} =
     CDict{owned, V}(Int64(0), Ptr{CString{owned}}(C_NULL), Ptr{V}(C_NULL))
 _zero_carrier(::Type{COpt{T}}) where {T} = COpt{T}(nothing)
 _zero_carrier(::Type{CArray{owned, T, N}}) where {owned, T, N} =
-    CArray{owned, T, N}(ntuple(_ -> Int32(0), Val(N)), Ptr{T}(C_NULL))
+    CArray{owned, T, N}(ntuple(_ -> Int64(0), Val(N)), Ptr{T}(C_NULL))

--- a/JLWInterop/test/runtests.jl
+++ b/JLWInterop/test/runtests.jl
@@ -57,7 +57,7 @@ using Test
         # Keep the borrowed buffer alive while using the view.
         buf = Float64[10.0, 20.0, 30.0, 40.0]
         GC.@preserve buf begin
-            v = CVector{:borrowed, Float64}(Int32(length(buf)), pointer(buf))
+            v = CVector{:borrowed, Float64}(Int64(length(buf)), pointer(buf))
 
             @test v isa AbstractVector{Float64}
             @test IndexStyle(typeof(v)) === IndexLinear()
@@ -87,7 +87,7 @@ using Test
 
     @testset "CString layout" begin
         @test fieldnames(CString{:borrowed}) == (:length, :data)
-        @test fieldtype(CString{:borrowed}, :length) === Int32
+        @test fieldtype(CString{:borrowed}, :length) === Int64
         @test fieldtype(CString{:borrowed}, :data) === Ptr{UInt8}
         @test isbitstype(CString{:borrowed})
         @test fieldoffset(CString{:borrowed}, 1) == 0
@@ -111,17 +111,17 @@ using Test
 
     @testset "CString constructors" begin
         # There is no ownership-defaulting constructor.
-        @test_throws MethodError CString(Int32(0), Ptr{UInt8}(0))
+        @test_throws MethodError CString(Int64(0), Ptr{UInt8}(0))
         @test_throws MethodError CString("hello")
 
         # Only :owned and :borrowed name an ownership.
         @test_throws(
             "ownership parameter must be :owned or :borrowed, got :mine",
-            CString{:mine}(Int32(0), Ptr{UInt8}(0))
+            CString{:mine}(Int64(0), Ptr{UInt8}(0))
         )
         @test_throws(
             "ownership parameter must be :owned or :borrowed, got 1",
-            CString{1}(Int32(0), Ptr{UInt8}(0))
+            CString{1}(Int64(0), Ptr{UInt8}(0))
         )
     end
 
@@ -142,7 +142,7 @@ using Test
     @testset "CString AbstractString interface" begin
         buf = codeunits("hello")
         GC.@preserve buf begin
-            s = CString{:borrowed}(Int32(length(buf)), pointer(buf))
+            s = CString{:borrowed}(Int64(length(buf)), pointer(buf))
 
             # AbstractString-derived methods.
             @test ncodeunits(s) === 5
@@ -164,7 +164,7 @@ using Test
         # Embedded NUL bytes are preserved (length-prefixed, not terminated).
         raw = UInt8[0x66, 0x00, 0x6f]  # "f\0o"
         GC.@preserve raw begin
-            s = CString{:borrowed}(Int32(length(raw)), pointer(raw))
+            s = CString{:borrowed}(Int64(length(raw)), pointer(raw))
             @test ncodeunits(s) === 3
             @test codeunit(s, 2) === 0x00
             @test String(s) == "f\0o"
@@ -173,7 +173,7 @@ using Test
         # Multi-byte UTF-8 ("café"): 4 characters, 5 bytes.
         utf8 = codeunits("café")
         GC.@preserve utf8 begin
-            s = CString{:borrowed}(Int32(length(utf8)), pointer(utf8))
+            s = CString{:borrowed}(Int64(length(utf8)), pointer(utf8))
             @test ncodeunits(s) === 5
             @test length(s) === 4
             @test collect(s) == ['c', 'a', 'f', 'é']
@@ -185,8 +185,8 @@ using Test
         a_buf = codeunits("apple")
         b_buf = codeunits("banana")
         GC.@preserve a_buf b_buf begin
-            a = CString{:borrowed}(Int32(length(a_buf)), pointer(a_buf))
-            b = CString{:borrowed}(Int32(length(b_buf)), pointer(b_buf))
+            a = CString{:borrowed}(Int64(length(a_buf)), pointer(a_buf))
+            b = CString{:borrowed}(Int64(length(b_buf)), pointer(b_buf))
             @test cmp(a, b) < 0
             @test cmp(b, a) > 0
             @test cmp(a, a) == 0
@@ -199,7 +199,7 @@ using Test
         # Column-major storage; verify both linear and Cartesian indexing.
         buf = Float64[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]  # 2x3, col-major
         GC.@preserve buf begin
-            m = CMatrix{:borrowed, Float64}(Int32(2), Int32(3), pointer(buf))
+            m = CMatrix{:borrowed, Float64}(Int64(2), Int64(3), pointer(buf))
 
             @test m isa AbstractMatrix{Float64}
             @test IndexStyle(typeof(m)) === IndexLinear()
@@ -275,28 +275,25 @@ using Test
         # C and Python emitters rely on this field layout.
         @test fieldnames(CArray) == (:dims, :data)
 
-        @test fieldtype(CVector{:borrowed, Float64}, :dims) === NTuple{1, Int32}
+        @test fieldtype(CVector{:borrowed, Float64}, :dims) === NTuple{1, Int64}
         @test fieldtype(CVector{:borrowed, Float64}, :data) === Ptr{Float64}
         @test isbitstype(CVector{:borrowed, Float64})
         @test iszero(fieldoffset(CVector{:borrowed, Float64}, 1))
-        # One Int32 (4 bytes) pads out to pointer alignment (8 bytes).
         @test fieldoffset(CVector{:borrowed, Float64}, 2) == 8
         @test sizeof(CVector{:borrowed, Float64}) == 16
 
-        @test fieldtype(CMatrix{:owned, Float64}, :dims) === NTuple{2, Int32}
+        @test fieldtype(CMatrix{:owned, Float64}, :dims) === NTuple{2, Int64}
         @test fieldtype(CMatrix{:owned, Float64}, :data) === Ptr{Float64}
         @test isbitstype(CMatrix{:owned, Float64})
         @test iszero(fieldoffset(CMatrix{:owned, Float64}, 1))
-        # Two Int32s pack tightly into 8 bytes, then data is pointer-aligned.
-        @test fieldoffset(CMatrix{:owned, Float64}, 2) == 8
-        @test sizeof(CMatrix{:owned, Float64}) == 16
+        @test fieldoffset(CMatrix{:owned, Float64}, 2) == 16
+        @test sizeof(CMatrix{:owned, Float64}) == 24
 
-        @test fieldtype(CArray{:borrowed, Float64, 3}, :dims) === NTuple{3, Int32}
+        @test fieldtype(CArray{:borrowed, Float64, 3}, :dims) === NTuple{3, Int64}
         @test isbitstype(CArray{:borrowed, Float64, 3})
         @test iszero(fieldoffset(CArray{:borrowed, Float64, 3}, 1))
-        # Three Int32s = 12 bytes, padded to 16 for pointer alignment.
-        @test fieldoffset(CArray{:borrowed, Float64, 3}, 2) == 16
-        @test sizeof(CArray{:borrowed, Float64, 3}) == 24
+        @test fieldoffset(CArray{:borrowed, Float64, 3}, 2) == 24
+        @test sizeof(CArray{:borrowed, Float64, 3}) == 32
 
         # Ownership is part of the type, so the two flavors are distinct types
         # with identical layout.
@@ -316,28 +313,28 @@ using Test
     end
 
     @testset "CArray constructors" begin
-        # Tuple dimensions convert to Int32; the ownership parameter is
+        # Tuple dimensions convert to Int64; the ownership parameter is
         # required at every entry point.
-        a = CArray{:borrowed, Float64}((Int32(2), Int32(3)), Ptr{Float64}(0))
+        a = CArray{:borrowed, Float64}((Int64(2), Int64(3)), Ptr{Float64}(0))
         @test a isa CMatrix{:borrowed, Float64}
-        @test a.dims === (Int32(2), Int32(3))
+        @test a.dims === (Int64(2), Int64(3))
 
         # `T` and `N` are both inferred from the pointer and dimensions.
         a2 = CArray{:borrowed}((2, 3), Ptr{Float64}(0))
         @test a2 isa CMatrix{:borrowed, Float64}
-        @test a2.dims === (Int32(2), Int32(3))
+        @test a2.dims === (Int64(2), Int64(3))
 
         a3 = CArray{:owned, Float64, 2}((2, 3), Ptr{Float64}(0))
         @test a3 isa CMatrix{:owned, Float64}
-        @test a3.dims === (Int32(2), Int32(3))
+        @test a3.dims === (Int64(2), Int64(3))
 
         # Scalar-form shortcuts for 1-D and 2-D.
-        v = CVector{:borrowed, Float64}(Int32(4), Ptr{Float64}(0))
-        @test v.dims === (Int32(4),)
+        v = CVector{:borrowed, Float64}(Int64(4), Ptr{Float64}(0))
+        @test v.dims === (Int64(4),)
         @test v.data === Ptr{Float64}(0)
 
         m = CMatrix{:owned, Float64}(2, 3, Ptr{Float64}(0))
-        @test m.dims === (Int32(2), Int32(3))
+        @test m.dims === (Int64(2), Int64(3))
 
         # There is no ownership-defaulting constructor.
         @test_throws MethodError CArray([1.0])
@@ -346,11 +343,11 @@ using Test
         # Only :owned and :borrowed name an ownership.
         @test_throws(
             "ownership parameter must be :owned or :borrowed, got :mine",
-            CArray{:mine, Float64, 1}((Int32(1),), Ptr{Float64}(0))
+            CArray{:mine, Float64, 1}((Int64(1),), Ptr{Float64}(0))
         )
         @test_throws(
             "ownership parameter must be :owned or :borrowed, got 1",
-            CArray{1, Float64, 1}((Int32(1),), Ptr{Float64}(0))
+            CArray{1, Float64, 1}((Int64(1),), Ptr{Float64}(0))
         )
     end
 
@@ -359,7 +356,7 @@ using Test
         src = [1.0 2.0; 3.0 4.0]  # 2x2, column-major
         a = CArray{:owned}(src)
         @test a isa CMatrix{:owned, Float64}
-        @test a.dims === (Int32(2), Int32(2))
+        @test a.dims === (Int64(2), Int64(2))
         @test collect(a) == src
         Libc.free(a.data)
 
@@ -373,7 +370,7 @@ using Test
         # borrowed carrier into an owning copy.
         buf = Float64[5.0, 6.0]
         GC.@preserve buf begin
-            borrowed = CVector{:borrowed, Float64}(Int32(2), pointer(buf))
+            borrowed = CVector{:borrowed, Float64}(Int64(2), pointer(buf))
             @test collect(borrowed) == [5.0, 6.0]
             copied = CArray{:owned}(borrowed)
             @test copied isa CVector{:owned, Float64}
@@ -390,20 +387,6 @@ using Test
         )
     end
 
-    @testset "CArray{:owned} narrows dims before allocating" begin
-        # `dims` is `NTuple{N,Int32}`, so a dimension past `typemax(Int32)` has
-        # no representation. The conversion must happen before the copy and the
-        # `malloc`: a throw after either one strands memory no one can free.
-        # `Base.OneTo` reports its size without holding storage.
-        huge = Base.OneTo(2^31)
-        @test_throws InexactError CArray{:owned}(huge)
-        allocated = @allocated try
-            CArray{:owned}(huge)
-        catch
-        end
-        @test allocated < 1024
-    end
-
     @testset "CArray{:borrowed} aliases dense arrays" begin
         # `DenseArray` storage is already contiguous and column-major, so the
         # constructor can alias it: `data` is `pointer(A)` and no copy is made.
@@ -412,7 +395,7 @@ using Test
         GC.@preserve buf begin
             v = CArray{:borrowed}(buf)
             @test v isa CVector{:borrowed, Float64}
-            @test v.dims === (Int32(3),)
+            @test v.dims === (Int64(3),)
             @test v.data === pointer(buf)
             # Genuine aliasing, in both directions.
             buf[2] = 20.0
@@ -425,7 +408,7 @@ using Test
         GC.@preserve M begin
             m = CArray{:borrowed}(M)
             @test m isa CMatrix{:borrowed, Float64}
-            @test m.dims === (Int32(2), Int32(2))
+            @test m.dims === (Int64(2), Int64(2))
             @test collect(m) == M
         end
 
@@ -451,14 +434,14 @@ using Test
         # so arrays whose axes do not start at 1 copy correctly.
         o = OffsetArray([10.0, 20.0, 30.0], -1:1)
         v = CArray{:owned}(o)
-        @test v.dims === (Int32(3),)
+        @test v.dims === (Int64(3),)
         @test size(v) == size(o)
         @test collect(v) == collect(o)
         Libc.free(v.data)
 
         o2 = OffsetArray([1.0 2.0; 3.0 4.0], 0:1, 5:6)
         m = CArray{:owned}(o2)
-        @test m.dims === (Int32(2), Int32(2))
+        @test m.dims === (Int64(2), Int64(2))
         @test size(m) == size(o2)
         @test collect(m) == collect(o2)
         Libc.free(m.data)
@@ -466,7 +449,7 @@ using Test
         # A non-contiguous view is densified by the copy.
         src = collect(1.0:6.0)
         w = CArray{:owned}(view(src, 2:2:6))
-        @test w.dims === (Int32(3),)
+        @test w.dims === (Int64(3),)
         @test collect(w) == [2.0, 4.0, 6.0]
         Libc.free(w.data)
     end
@@ -653,7 +636,7 @@ using Test
 
         # zero carriers for every carrier type
         @test iszero(JLWInterop._zero_carrier(Int64))
-        @test JLWInterop._zero_carrier(CString{:owned}).length == Int32(0)
+        @test JLWInterop._zero_carrier(CString{:owned}).length == Int64(0)
         @test JLWInterop._zero_carrier(CStrArray{:owned}).data == Ptr{CString{:owned}}(C_NULL)
         @test JLWInterop._zero_carrier(CDict{:owned, Float64}).keys == Ptr{CString{:owned}}(C_NULL)
         @test JLWInterop._zero_carrier(COpt{Float64}).has_value == Int32(0)

--- a/JuliaLibWrapping/docs/src/jlwinterop.md
+++ b/JuliaLibWrapping/docs/src/jlwinterop.md
@@ -58,7 +58,7 @@ JLW_MESSAGE_BYTES
 
 ## `CArray{owned,T,N}` — N-D numeric buffer (column-major)
 
-`CArray{owned,T,N}` is `(dims::NTuple{N,Int32}, data::Ptr{T})` in column-major
+`CArray{owned,T,N}` is `(dims::NTuple{N,Int64}, data::Ptr{T})` in column-major
 order. Targets may map this layout to native array types.
 
 ### `CArray` ownership contract
@@ -124,7 +124,7 @@ CMatrix
 
 ## `CString{owned}` — length-prefixed UTF-8
 
-`CString{owned}` is `(length::Int32, data::Ptr{UInt8})`. It is length-prefixed,
+`CString{owned}` is `(length::Int64, data::Ptr{UInt8})`. It is length-prefixed,
 so it permits embedded NUL bytes.
 
 `CString{owned} <: AbstractString`; call `String(s)` to copy the bytes into a
@@ -159,9 +159,6 @@ CString
 `CStrArray{owned}` is `(length::Int64, data::Ptr{CString{owned}})`: a pointer
 to `length` [`CString`](@ref)s with matching ownership. Converting it to
 `Vector{String}` copies the strings without freeing the source.
-
-Each string uses an `Int32` byte length; oversized strings throw
-`InexactError` rather than being truncated.
 
 ### `CStrArray` ownership contract
 

--- a/JuliaLibWrapping/examples/abi_stress/src/abi_stress.jl
+++ b/JuliaLibWrapping/examples/abi_stress/src/abi_stress.jl
@@ -9,7 +9,7 @@ module abi_stress
 # Kept in sync with JLWInterop.CArray so the recognizer still matches:
 # ownership is a leading Symbol type parameter and the layout is two fields.
 struct CArray{owned, T, N}
-    dims::NTuple{N, Int32}
+    dims::NTuple{N, Int64}
     data::Ptr{T}
 end
 const CVector{owned, T} = CArray{owned, T, 1}
@@ -28,7 +28,7 @@ struct MyTwoVec
     y::Int32
 end
 
-Base.@ccallable function tree_size(tree::CTree{Float64})::Int
+Base.@ccallable function tree_size(tree::CTree{Float64})::Int64
     n = 1
     for i in 1:tree.children.dims[1]
         n += tree_size(unsafe_load(tree.children.data, i))
@@ -58,10 +58,10 @@ end
 
 # Exercises the N=3 case: the JuliaLibWrapping wrapper emitters generate the
 # rank-agnostic CArray helpers, and juliac's "array" ABI kind carries the
-# `NTuple{3,Int32}` shape.
+# `NTuple{3,Int64}` shape.
 Base.@ccallable function sum3d(a::CArray{:borrowed, Float64, 3})::Float64
     s = 0.0
-    n = Int(a.dims[1]) * Int(a.dims[2]) * Int(a.dims[3])
+    n = a.dims[1] * a.dims[2] * a.dims[3]
     for i in 1:n
         s += unsafe_load(a.data, i)
     end

--- a/JuliaLibWrapping/src/abi_import.jl
+++ b/JuliaLibWrapping/src/abi_import.jl
@@ -7,9 +7,9 @@ end
 struct PrimitiveTypeDesc
     name::String
     signed::Bool
-    bits::UInt
-    size::UInt
-    alignment::UInt
+    bits::Int
+    size::Int
+    alignment::Int
 end
 
 struct StructDesc

--- a/JuliaLibWrapping/src/python.jl
+++ b/JuliaLibWrapping/src/python.jl
@@ -220,18 +220,17 @@ const scalar_payload_types = Dict{String, String}(
 [`carray_struct_info`](@ref) with this emitter's type tables applied:
 `nothing` unless the struct matches the `CArray` shape and its element type
 has a [`numpy_dtypes`](@ref) entry; otherwise
-`(; eltype, ndim, ownership, ctype, dtype)`, adding the element type's
-`ctypes` expression ([`pytypes`](@ref)) and numpy dtype to the recognizer's
-fields.
+`(; eltype, ndim, ownership, dims_bits, ctype, dtype, dims_ctype)`.
 """
 function _python_carray_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
     info = carray_struct_info(desc, typeinfo)
     info === nothing && return nothing
     haskey(numpy_dtypes, info.eltype) || return nothing
     return (;
-        info.eltype, info.ndim, info.ownership,
+        info.eltype, info.ndim, info.ownership, info.dims_bits,
         ctype = pytypes[info.eltype],
         dtype = numpy_dtypes[info.eltype],
+        dims_ctype = pytypes[info.dims_type],
     )
 end
 
@@ -241,13 +240,16 @@ end
 [`cdict_struct_info`](@ref) with this emitter's type tables applied:
 `nothing` unless the struct matches the `CDict` shape and its value type
 has a [`scalar_payload_types`](@ref) entry; otherwise
-`(; value_type, ownership, ctype)`.
+`(; value_type, ownership, length_bits, ctype)`.
 """
 function _python_cdict_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
     info = cdict_struct_info(desc, typeinfo)
     info === nothing && return nothing
     haskey(scalar_payload_types, info.value_type) || return nothing
-    return (; info.value_type, info.ownership, ctype = scalar_payload_types[info.value_type])
+    return (;
+        info.value_type, info.ownership, info.length_bits,
+        ctype = scalar_payload_types[info.value_type],
+    )
 end
 
 """
@@ -311,21 +313,40 @@ function _python_status_path(method::MethodDesc, typeinfo::OrderedDict{Int, Type
 end
 
 """
-    _cstring_pointee_classname(desc, fieldname, typeinfo, typedict) -> String
+    _cstring_pointee_info(desc, fieldname, typeinfo, typedict) -> NamedTuple
 
-Return the mangled Python `ctypes.Structure` class name for the
-`CString` struct pointed to by `desc`'s field named `fieldname`
-(`"data"` for [`cstrarray_struct_info`](@ref), `"keys"` for
-[`cdict_struct_info`](@ref)). The caller must first verify that the field
-points to a `CString` with matching ownership.
+Return the Python class name and `length` width of the `CString` pointed to by
+the field named `fieldname`. The caller must first validate the field.
 """
-function _cstring_pointee_classname(
+function _cstring_pointee_info(
         desc::StructDesc, fieldname::String,
         typeinfo::OrderedDict{Int, TypeDesc}, typedict::Dict{Int, String}
     )
     field = only(f for f in desc.fields if f.name == fieldname)
     pointee_id = (typeinfo[field.type]::PointerDesc).pointee_type
-    return typedict[pointee_id]
+    pointee = typeinfo[pointee_id]::StructDesc
+    info = cstring_struct_info(pointee, typeinfo)
+    return (; classname = typedict[pointee_id], length_bits = info.length_bits)
+end
+
+"""
+    _emit_length_guard(f, indent, expr, bits, what)
+
+Emit a range check before assigning the Python expression `expr` to a signed
+`bits`-wide field. No check is emitted for 64-bit fields. `expr` must be
+side-effect free.
+"""
+function _emit_length_guard(
+        f::IO, indent::AbstractString, expr::AbstractString,
+        bits::Integer, what::AbstractString
+    )
+    bits >= 64 && return nothing
+    limit = "0x" * string(2^(bits - 1) - 1; base = 16)
+    println(f, indent, "if ", expr, " > ", limit, ":")
+    return println(
+        f, indent, "    raise OverflowError(f\"", what, " {", expr,
+        "} exceeds the library's ", bits, "-bit length field\")"
+    )
 end
 
 const PYTHON_KEYWORDS = Set{String}(
@@ -666,7 +687,15 @@ function _write_carray_helpers(
         println(f, "        expected_dtype = np.dtype(", repr(dtype), ")")
         println(f, "        if arr.dtype != expected_dtype:")
         println(f, "            raise ValueError(f\"expected dtype ", dtype, ", got {arr.dtype}\")")
-        println(f, "        obj = cls(dims=(ctypes.c_int32 * ", ndim, ")(*arr.shape),")
+        if cainfo.dims_bits < 64
+            limit = "0x" * string(2^(cainfo.dims_bits - 1) - 1; base = 16)
+            println(f, "        if any(d > ", limit, " for d in arr.shape):")
+            println(
+                f, "            raise OverflowError(f\"array shape {arr.shape} exceeds ",
+                "the library's ", cainfo.dims_bits, "-bit dims field\")"
+            )
+        end
+        println(f, "        obj = cls(dims=(", cainfo.dims_ctype, " * ", ndim, ")(*arr.shape),")
         println(f, "                  data=arr.ctypes.data_as(ctypes.POINTER(", ctype, ")))")
         println(f, "        obj._buffer = arr")
         println(f, "        return obj")
@@ -727,6 +756,7 @@ function _write_cstring_helpers(
         println(f, "        if not isinstance(b, (bytes, bytearray)):")
         println(f, "            raise TypeError(f\"expected bytes-like, got {type(b).__name__}\")")
         println(f, "        n = len(b)")
+        _emit_length_guard(f, "        ", "n", csinfo.length_bits, "string length")
         println(f, "        buf = (ctypes.c_uint8 * n).from_buffer_copy(b) if n else (ctypes.c_uint8 * 0)()")
         println(f, "        obj = cls(length=n,")
         println(f, "                  data=ctypes.cast(buf, ctypes.POINTER(ctypes.c_uint8)))")
@@ -752,7 +782,7 @@ function _write_cstring_helpers(
 end
 
 """
-    _emit_cstring_array(f, list_var, arr_var, source_expr, item_var, cstring_classname)
+    _emit_cstring_array(f, list_var, arr_var, source_expr, item_var, cstring_classname, element_bits)
 
 Emit the "encode each string into a raw (non-NUL-terminated) buffer, then
 build a `ctypes` array of `<cstring_classname>` structs, each holding that
@@ -768,16 +798,22 @@ only — the inner per-buffer comprehension's loop variable is always `b`, so
 both call sites emit identical text apart from the substituted names.
 Embedded NUL bytes in the source strings survive intact: each element's
 `length` is the exact byte count, not a NUL-terminator search.
+
+`element_bits` controls the per-element length check.
 """
 function _emit_cstring_array(
         f::IO, list_var::AbstractString, arr_var::AbstractString,
         source_expr::AbstractString, item_var::AbstractString,
-        cstring_classname::AbstractString
+        cstring_classname::AbstractString, element_bits::Integer
     )
     println(
         f, "        ", list_var, " = [", item_var, ".encode(\"utf-8\") for ",
         item_var, " in ", source_expr, "]"
     )
+    if element_bits < 64
+        println(f, "        for b in ", list_var, ":")
+        _emit_length_guard(f, "            ", "len(b)", element_bits, "string length")
+    end
     println(f, "        ", arr_var, " = (", cstring_classname, " * len(", list_var, "))(")
     return println(
         f, "            *[", cstring_classname, "(length=len(b), data=ctypes.cast(",
@@ -787,24 +823,26 @@ function _emit_cstring_array(
 end
 
 """
-    _write_cstrarray_helpers(f, csainfo, classname, cstring_classname, release_present)
+    _write_cstrarray_helpers(f, csainfo, classname, cstring, release_present)
 
 Emit the conversion methods on a recognized `CStrArray` `ctypes` class. The
 borrowed class gets `from_list` and `as_list`; the owned class gets `as_list`
-and `free()`.
+and `free()`. `cstring` describes the element type and length width.
 """
 function _write_cstrarray_helpers(
         f::IO, csainfo, classname::AbstractString,
-        cstring_classname::AbstractString, release_present::Bool
+        cstring, release_present::Bool
     )
     owned = csainfo.ownership === :owned
+    cstring_classname = cstring.classname
     if csainfo.ownership === :borrowed
         println(f, "")
         println(f, "    @classmethod")
         println(f, "    def from_list(cls, items):")
         println(f, "        if not isinstance(items, (list, tuple)):")
         println(f, "            raise TypeError(\"expected a list of str\")")
-        _emit_cstring_array(f, "bufs", "arr", "items", "s", cstring_classname)
+        _emit_cstring_array(f, "bufs", "arr", "items", "s", cstring_classname, cstring.length_bits)
+        _emit_length_guard(f, "        ", "len(bufs)", csainfo.length_bits, "list length")
         println(
             f, "        obj = cls(length=len(bufs), data=ctypes.cast(arr, ctypes.POINTER(",
             cstring_classname, ")))"
@@ -829,23 +867,25 @@ function _write_cstrarray_helpers(
 end
 
 """
-    _write_cdict_helpers(f, cdinfo, classname, cstring_classname, release_present)
+    _write_cdict_helpers(f, cdinfo, classname, cstring, release_present)
 
 Emit the conversion methods on a recognized `CDict` `ctypes` class. The
 borrowed class gets `from_dict` and `as_dict`; the owned class gets `as_dict`
-and `free()`.
+and `free()`. `cstring` describes the key type and length width.
 """
 function _write_cdict_helpers(
         f::IO, cdinfo, classname::AbstractString,
-        cstring_classname::AbstractString, release_present::Bool
+        cstring, release_present::Bool
     )
     ctype = cdinfo.ctype
     owned = cdinfo.ownership === :owned
+    cstring_classname = cstring.classname
     if cdinfo.ownership === :borrowed
         println(f, "")
         println(f, "    @classmethod")
         println(f, "    def from_dict(cls, d):")
-        _emit_cstring_array(f, "keys", "karr", "d.keys()", "k", cstring_classname)
+        _emit_cstring_array(f, "keys", "karr", "d.keys()", "k", cstring_classname, cstring.length_bits)
+        _emit_length_guard(f, "        ", "len(keys)", cdinfo.length_bits, "dict length")
         println(f, "        varr = (", ctype, " * len(keys))(*d.values())")
         println(f, "        obj = cls(length=len(keys),")
         println(f, "                  keys=ctypes.cast(karr, ctypes.POINTER(", cstring_classname, ")),")
@@ -1066,12 +1106,12 @@ function _write_bindings(
                 _write_cstring_helpers(f, csinfo, name, release_present)
             elseif !isnothing(csainfo)
                 # Emit CStrArray conversion helpers.
-                cs_classname = _cstring_pointee_classname(type, "data", typeinfo, typedict)
-                _write_cstrarray_helpers(f, csainfo, name, cs_classname, release_present)
+                cs = _cstring_pointee_info(type, "data", typeinfo, typedict)
+                _write_cstrarray_helpers(f, csainfo, name, cs, release_present)
             elseif !isnothing(cdinfo)
                 # Emit CDict conversion helpers.
-                cs_classname = _cstring_pointee_classname(type, "keys", typeinfo, typedict)
-                _write_cdict_helpers(f, cdinfo, name, cs_classname, release_present)
+                cs = _cstring_pointee_info(type, "keys", typeinfo, typedict)
+                _write_cdict_helpers(f, cdinfo, name, cs, release_present)
             elseif !isnothing(coinfo)
                 # Emit COpt conversion helpers.
                 _write_copt_helpers(f, coinfo)

--- a/JuliaLibWrapping/src/recognizers.jl
+++ b/JuliaLibWrapping/src/recognizers.jl
@@ -1,7 +1,7 @@
 # Target-independent, structural recognition of JLWInterop carriers.
 #
-# Recognizers report Julia-level facts (primitive type names, field names,
-# dimension counts); each emitter translates those into its own type names
+# Recognizers report Julia-level facts (primitive names and widths, field names,
+# and dimension counts); each emitter translates those into its own type names
 # and decides which element types it supports (e.g. `_python_carray_info`
 # in `python.jl`).
 
@@ -22,6 +22,19 @@ function _match_fields(desc::StructDesc, names::NTuple{N, String}) where {N}
 end
 
 """
+    _integer_field_info(desc) -> Union{Nothing, NamedTuple}
+
+Return `(; name, bits)` for a signed 32- or 64-bit primitive integer, or
+`nothing`.
+"""
+function _integer_field_info(@nospecialize(desc))
+    desc isa PrimitiveTypeDesc || return nothing
+    desc.signed || return nothing
+    desc.bits in (32, 64) || return nothing
+    return (; name = desc.name, bits = desc.bits)
+end
+
+"""
     is_jlwstatus_struct(desc::StructDesc, typeinfo) -> Bool
 
 Recognize `JLWStatus` by name and field layout.
@@ -32,9 +45,7 @@ function is_jlwstatus_struct(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDe
     code_field, msg_field = desc.fields
     code_field.name == "code" || return false
     msg_field.name == "message" || return false
-    code_type = typeinfo[code_field.type]
-    code_type isa PrimitiveTypeDesc || return false
-    code_type.name in ("Int32", "Int64") || return false
+    isnothing(_integer_field_info(typeinfo[code_field.type])) && return false
     msg_type = typeinfo[msg_field.type]
     msg_type isa ArrayDesc || return false
     eltype = typeinfo[msg_type.element_type]
@@ -69,48 +80,40 @@ end
 """
     cstring_struct_info(desc::StructDesc, typeinfo) -> Union{Nothing, NamedTuple}
 
-Recognize `CString` by name and field layout. The name must carry an explicit
-leading ownership parameter (see [`_carrier_ownership`](@ref)) and the layout
-must be exactly two fields: `length`, a primitive integer, and `data`, a
-pointer to `UInt8`. Field order is unrestricted. On a match, return
-`(; ownership)` — `:owned` or `:borrowed`. Otherwise return `nothing`;
-ownership is never inferred from a name that does not state it.
+Recognize `CString` with explicit ownership, a signed 32- or 64-bit `length`,
+and a `data` pointer to `UInt8`. Return
+`(; ownership, length_type, length_bits)`, or `nothing`.
 """
 function cstring_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
     ownership = _carrier_ownership(desc.name, ("CString{",))
     isnothing(ownership) && return nothing
     m = _match_fields(desc, ("length", "data"))
     isnothing(m) && return nothing
-    length_type = typeinfo[m.length.type]
-    length_type isa PrimitiveTypeDesc || return nothing
-    (startswith(length_type.name, "Int") || startswith(length_type.name, "UInt")) || return nothing
+    len = _integer_field_info(typeinfo[m.length.type])
+    isnothing(len) && return nothing
     data_type = typeinfo[m.data.type]
     data_type isa PointerDesc || return nothing
     data_type.pointee_type === nothing && return nothing # `void` pointee
     pointee = typeinfo[data_type.pointee_type]
     pointee isa PrimitiveTypeDesc || return nothing
     pointee.name == "UInt8" || return nothing
-    return (; ownership)
+    return (; ownership, length_type = len.name, length_bits = len.bits)
 end
 
 """
     cstrarray_struct_info(desc::StructDesc, typeinfo) -> Union{Nothing, NamedTuple}
 
-Recognize `CStrArray` by name and field layout. The name must carry an
-explicit leading ownership parameter (see [`_carrier_ownership`](@ref)) and
-the layout must be exactly two fields: `length`, a signed primitive integer,
-and `data`, a pointer to a struct matching [`cstring_struct_info`](@ref) whose
-own ownership is the same. Field order is unrestricted. On a match, return
-`(; ownership)` — `:owned` or `:borrowed`. Otherwise return `nothing`;
-ownership is never inferred from a name that does not state it.
+Recognize `CStrArray` with explicit ownership, a signed 32- or 64-bit
+`length`, and a `data` pointer to a matching `CString`. Return
+`(; ownership, length_type, length_bits)`, or `nothing`.
 """
 function cstrarray_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
     ownership = _carrier_ownership(desc.name, ("CStrArray{",))
     isnothing(ownership) && return nothing
     m = _match_fields(desc, ("length", "data"))
     isnothing(m) && return nothing
-    length_type = typeinfo[m.length.type]
-    length_type isa PrimitiveTypeDesc && length_type.signed || return nothing
+    len = _integer_field_info(typeinfo[m.length.type])
+    isnothing(len) && return nothing
     data_type = typeinfo[m.data.type]
     data_type isa PointerDesc || return nothing
     data_type.pointee_type === nothing && return nothing # `void` pointee
@@ -119,29 +122,23 @@ function cstrarray_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, Type
     element = cstring_struct_info(pointee, typeinfo)
     isnothing(element) && return nothing
     element.ownership === ownership || return nothing
-    return (; ownership)
+    return (; ownership, length_type = len.name, length_bits = len.bits)
 end
 
 """
     cdict_struct_info(desc::StructDesc, typeinfo) -> Union{Nothing, NamedTuple}
 
-Recognize `CDict` by name and field layout. The name must carry an explicit
-leading ownership parameter (see [`_carrier_ownership`](@ref)) and the layout
-must be exactly three fields: `length`, a primitive integer; `keys`, a pointer
-to a struct matching [`cstring_struct_info`](@ref) whose own ownership is the
-same; and `values`, a pointer to a primitive type. On a match, return
-`(; value_type, ownership)` — the Julia name of the value type (e.g.
-`"Float64"`) and `:owned` or `:borrowed`. Otherwise return `nothing`;
-ownership is never inferred from a name that does not state it.
+Recognize `CDict` with explicit ownership, a signed 32- or 64-bit `length`,
+`CString` keys, and primitive values. Return
+`(; value_type, ownership, length_type, length_bits)`, or `nothing`.
 """
 function cdict_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
     ownership = _carrier_ownership(desc.name, ("CDict{",))
     isnothing(ownership) && return nothing
     m = _match_fields(desc, ("length", "keys", "values"))
     isnothing(m) && return nothing
-    length_type = typeinfo[m.length.type]
-    length_type isa PrimitiveTypeDesc || return nothing
-    (startswith(length_type.name, "Int") || startswith(length_type.name, "UInt")) || return nothing
+    len = _integer_field_info(typeinfo[m.length.type])
+    isnothing(len) && return nothing
     keys_type = typeinfo[m.keys.type]
     keys_type isa PointerDesc || return nothing
     keys_type.pointee_type === nothing && return nothing # `void` pointee
@@ -155,25 +152,30 @@ function cdict_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc
     values_type.pointee_type === nothing && return nothing # `void` pointee
     values_pointee = typeinfo[values_type.pointee_type]
     values_pointee isa PrimitiveTypeDesc || return nothing
-    return (; value_type = values_pointee.name, ownership)
+    return (;
+        value_type = values_pointee.name, ownership,
+        length_type = len.name, length_bits = len.bits,
+    )
 end
 
 """
     copt_struct_info(desc::StructDesc, typeinfo) -> Union{Nothing, NamedTuple}
 
-Recognize `COpt` by name and field layout. Return `(; value_type)` (the
-Julia name of the payload type, e.g. `"Float64"`), or `nothing`.
+Recognize `COpt` with a signed 32- or 64-bit `has_value` and primitive `value`.
+Return `(; value_type, has_value_type, has_value_bits)`, or `nothing`.
 """
 function copt_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
     startswith(desc.name, "COpt") || return nothing
     m = _match_fields(desc, ("has_value", "value"))
     isnothing(m) && return nothing
-    hv_type = typeinfo[m.has_value.type]
-    hv_type isa PrimitiveTypeDesc || return nothing
-    hv_type.name == "Int32" || return nothing
+    hv = _integer_field_info(typeinfo[m.has_value.type])
+    isnothing(hv) && return nothing
     value_type = typeinfo[m.value.type]
     value_type isa PrimitiveTypeDesc || return nothing
-    return (; value_type = value_type.name)
+    return (;
+        value_type = value_type.name,
+        has_value_type = hv.name, has_value_bits = hv.bits,
+    )
 end
 
 """
@@ -225,14 +227,9 @@ end
 """
     carray_struct_info(desc::StructDesc, typeinfo) -> Union{Nothing, NamedTuple}
 
-Recognize `CArray`, `CVector`, or `CMatrix` by name and field layout. The
-name must carry an explicit leading ownership parameter (see
-[`_carrier_ownership`](@ref)) and the layout must be exactly two fields:
-`dims`, an `NTuple` of a signed or unsigned integer type, and `data`, a
-pointer to a primitive type. On a match, return
-`(; eltype, ndim, ownership)` — the Julia name of the element type, the
-`dims` array's `count`, and `:owned` or `:borrowed`. Otherwise return
-`nothing`; ownership is never inferred from a name that does not state it.
+Recognize `CArray`, `CVector`, or `CMatrix` with explicit ownership, signed
+32- or 64-bit dimensions, and primitive data. Return
+`(; eltype, ndim, ownership, dims_type, dims_bits)`, or `nothing`.
 """
 function carray_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDesc})
     ownership = _carrier_ownership(desc.name, ("CArray{", "CVector{", "CMatrix{"))
@@ -241,15 +238,17 @@ function carray_struct_info(desc::StructDesc, typeinfo::OrderedDict{Int, TypeDes
     isnothing(m) && return nothing
     dims_type = typeinfo[m.dims.type]
     dims_type isa ArrayDesc || return nothing
-    dims_eltype = typeinfo[dims_type.element_type]
-    dims_eltype isa PrimitiveTypeDesc || return nothing
-    (startswith(dims_eltype.name, "Int") || startswith(dims_eltype.name, "UInt")) || return nothing
+    dims_eltype = _integer_field_info(typeinfo[dims_type.element_type])
+    isnothing(dims_eltype) && return nothing
     data_type = typeinfo[m.data.type]
     data_type isa PointerDesc || return nothing
     data_type.pointee_type === nothing && return nothing # `void` pointee
     pointee = typeinfo[data_type.pointee_type]
     pointee isa PrimitiveTypeDesc || return nothing
-    return (; eltype = pointee.name, ndim = dims_type.count, ownership)
+    return (;
+        eltype = pointee.name, ndim = dims_type.count, ownership,
+        dims_type = dims_eltype.name, dims_bits = dims_eltype.bits,
+    )
 end
 
 """

--- a/JuliaLibWrapping/test/bindinginfo_api_scale.json
+++ b/JuliaLibWrapping/test/bindinginfo_api_scale.json
@@ -56,12 +56,12 @@
     },
     {
       "kind": "array",
-      "name": "NTuple{1, Int32}",
+      "name": "NTuple{1, Int64}",
       "id": 7,
-      "element_type_id": 1,
+      "element_type_id": 10,
       "count": 1,
-      "size": 4,
-      "alignment": 4
+      "size": 8,
+      "alignment": 8
     },
     {
       "kind": "struct",
@@ -117,7 +117,7 @@
       "id": 12,
       "size": 16,
       "fields": [
-        { "name": "length", "isptr": false, "offset": 0, "isfieldatomic": false, "type_id": 1 },
+        { "name": "length", "isptr": false, "offset": 0, "isfieldatomic": false, "type_id": 10 },
         { "name": "data", "isptr": false, "offset": 8, "isfieldatomic": false, "type_id": 11 }
       ],
       "alignment": 8
@@ -128,7 +128,7 @@
       "id": 13,
       "size": 16,
       "fields": [
-        { "name": "length", "isptr": false, "offset": 0, "isfieldatomic": false, "type_id": 1 },
+        { "name": "length", "isptr": false, "offset": 0, "isfieldatomic": false, "type_id": 10 },
         { "name": "data", "isptr": false, "offset": 8, "isfieldatomic": false, "type_id": 11 }
       ],
       "alignment": 8

--- a/JuliaLibWrapping/test/bindinginfo_carray3.json
+++ b/JuliaLibWrapping/test/bindinginfo_carray3.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Hand-authored fixture for CArray{owned,T,3} — locks in coverage of higher-rank arrays beyond the CVector (N=1) and CMatrix (N=2) special cases. Mirrors the layout juliac emits for `struct CArray{:borrowed,Float64,3}; dims::NTuple{3,Int32}; data::Ptr{Float64}; end` with a single @ccallable function consuming one. The Python emitter must recognize this shape and emit the rank-agnostic, borrowed-flavored from_numpy/as_numpy helpers (column-major, no free).",
+  "_comment": "Hand-authored fixture for CArray{owned,T,3} — locks in coverage of higher-rank arrays beyond the CVector (N=1) and CMatrix (N=2) special cases. Mirrors the layout juliac emits for `struct CArray{:borrowed,Float64,3}; dims::NTuple{3,Int64}; data::Ptr{Float64}; end` with a single @ccallable function consuming one. The Python emitter must recognize this shape and emit the rank-agnostic, borrowed-flavored from_numpy/as_numpy helpers (column-major, no free).",
   "types": [
     {
       "kind": "primitive",
@@ -12,12 +12,12 @@
     },
     {
       "kind": "primitive",
-      "name": "Int32",
+      "name": "Int64",
       "id": 2,
-      "size": 4,
-      "bits": 32,
+      "size": 8,
+      "bits": 64,
       "signed": true,
-      "alignment": 4
+      "alignment": 8
     },
     {
       "kind": "pointer",
@@ -27,21 +27,21 @@
     },
     {
       "kind": "array",
-      "name": "NTuple{3, Int32}",
+      "name": "NTuple{3, Int64}",
       "id": 5,
       "element_type_id": 2,
       "count": 3,
-      "size": 12,
-      "alignment": 4
+      "size": 24,
+      "alignment": 8
     },
     {
       "kind": "struct",
       "name": "CArray{:borrowed, Float64, 3}",
       "id": 4,
-      "size": 24,
+      "size": 32,
       "fields": [
         { "name": "dims", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 3, "offset": 16, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 3, "offset": 24, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     }

--- a/JuliaLibWrapping/test/bindinginfo_carray_owned.json
+++ b/JuliaLibWrapping/test/bindinginfo_carray_owned.json
@@ -1,18 +1,18 @@
 {
-  "_comment": "Hand-authored fixture for an owning CArray return. Mirrors the layout juliac emits for `struct CVector{:owned,Float64}; dims::NTuple{1,Int32}; data::Ptr{Float64}; end`, with one @ccallable function returning a freshly allocated CVector{:owned, Float64}, plus the macro-emitted jlw_free/jlw_free_strings release entrypoints so the owning return is `:auto` (copy, then free in a `finally`), not `:mechanical`. No CArray-consuming function is needed here — carray3/cmatrix/libsimple already cover the borrowed-argument path; this fixture exists solely to exercise the owning-return facade shape.",
+  "_comment": "Hand-authored fixture for an owning CArray return. Mirrors the layout juliac emits for `struct CVector{:owned,Float64}; dims::NTuple{1,Int64}; data::Ptr{Float64}; end`, with one @ccallable function returning a freshly allocated CVector{:owned, Float64}, plus the macro-emitted jlw_free/jlw_free_strings release entrypoints so the owning return is `:auto` (copy, then free in a `finally`), not `:mechanical`. No CArray-consuming function is needed here — carray3/cmatrix/libsimple already cover the borrowed-argument path; this fixture exists solely to exercise the owning-return facade shape.",
   "functions": [
     {
       "symbol": "give_vec",
       "name": "give_vec()",
       "arguments": [
       ],
-      "returns": { "type_id": 6 }
+      "returns": { "type_id": 5 }
     },
     {
       "symbol": "jlw_free",
       "name": "jlw_free(p::Ptr{Nothing})",
       "arguments": [
-        { "name": "p", "type_id": 11 }
+        { "name": "p", "type_id": 10 }
       ],
       "returns": { "type_id": null }
     },
@@ -20,8 +20,8 @@
       "symbol": "jlw_free_strings",
       "name": "jlw_free_strings(p::Ptr{CString{:owned}}, n::Int64)",
       "arguments": [
-        { "name": "p", "type_id": 10 },
-        { "name": "n", "type_id": 3 }
+        { "name": "p", "type_id": 9 },
+        { "name": "n", "type_id": 2 }
       ],
       "returns": { "type_id": null }
     }
@@ -39,15 +39,6 @@
     {
       "id": 2,
       "kind": "primitive",
-      "name": "Int32",
-      "signed": true,
-      "bits": 32,
-      "size": 4,
-      "alignment": 4
-    },
-    {
-      "id": 3,
-      "kind": "primitive",
       "name": "Int64",
       "signed": true,
       "bits": 64,
@@ -55,33 +46,33 @@
       "alignment": 8
     },
     {
-      "id": 4,
+      "id": 3,
       "kind": "pointer",
       "name": "Ptr{Float64}",
       "pointee_type_id": 1
     },
     {
-      "id": 5,
+      "id": 4,
       "kind": "array",
-      "name": "NTuple{1, Int32}",
+      "name": "NTuple{1, Int64}",
       "element_type_id": 2,
       "count": 1,
-      "size": 4,
-      "alignment": 4
+      "size": 8,
+      "alignment": 8
     },
     {
-      "id": 6,
+      "id": 5,
       "kind": "struct",
       "name": "CVector{:owned, Float64}",
       "size": 16,
       "alignment": 8,
       "fields": [
-        { "name": "dims", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 4, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "dims", "type_id": 4, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
       ]
     },
     {
-      "id": 7,
+      "id": 6,
       "kind": "primitive",
       "name": "UInt8",
       "signed": false,
@@ -90,33 +81,33 @@
       "alignment": 1
     },
     {
-      "id": 8,
+      "id": 7,
       "kind": "pointer",
       "name": "Ptr{UInt8}",
-      "pointee_type_id": 7
+      "pointee_type_id": 6
     },
     {
-      "id": 9,
+      "id": 8,
       "kind": "struct",
       "name": "CString{:owned}",
       "size": 16,
       "alignment": 8,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 8, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 7, "offset": 8, "isptr": false, "isfieldatomic": false }
       ]
+    },
+    {
+      "id": 9,
+      "kind": "pointer",
+      "name": "Ptr{CString{:owned}}",
+      "pointee_type_id": 8
     },
     {
       "id": 10,
       "kind": "pointer",
-      "name": "Ptr{CString{:owned}}",
-      "pointee_type_id": 9
-    },
-    {
-      "id": 11,
-      "kind": "pointer",
       "name": "Ptr{Nothing}",
       "pointee_type_id": null
     }
-  ]
+]
 }

--- a/JuliaLibWrapping/test/bindinginfo_carray_owned_nofree.json
+++ b/JuliaLibWrapping/test/bindinginfo_carray_owned_nofree.json
@@ -6,7 +6,7 @@
       "name": "give_vec()",
       "arguments": [
       ],
-      "returns": { "type_id": 6 }
+      "returns": { "type_id": 5 }
     }
   ],
   "types": [
@@ -22,15 +22,6 @@
     {
       "id": 2,
       "kind": "primitive",
-      "name": "Int32",
-      "signed": true,
-      "bits": 32,
-      "size": 4,
-      "alignment": 4
-    },
-    {
-      "id": 3,
-      "kind": "primitive",
       "name": "Int64",
       "signed": true,
       "bits": 64,
@@ -38,33 +29,33 @@
       "alignment": 8
     },
     {
-      "id": 4,
+      "id": 3,
       "kind": "pointer",
       "name": "Ptr{Float64}",
       "pointee_type_id": 1
     },
     {
-      "id": 5,
+      "id": 4,
       "kind": "array",
-      "name": "NTuple{1, Int32}",
+      "name": "NTuple{1, Int64}",
       "element_type_id": 2,
       "count": 1,
-      "size": 4,
-      "alignment": 4
+      "size": 8,
+      "alignment": 8
     },
     {
-      "id": 6,
+      "id": 5,
       "kind": "struct",
       "name": "CVector{:owned, Float64}",
       "size": 16,
       "alignment": 8,
       "fields": [
-        { "name": "dims", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 4, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "dims", "type_id": 4, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
       ]
     },
     {
-      "id": 7,
+      "id": 6,
       "kind": "primitive",
       "name": "UInt8",
       "signed": false,
@@ -73,33 +64,33 @@
       "alignment": 1
     },
     {
-      "id": 8,
+      "id": 7,
       "kind": "pointer",
       "name": "Ptr{UInt8}",
-      "pointee_type_id": 7
+      "pointee_type_id": 6
     },
     {
-      "id": 9,
+      "id": 8,
       "kind": "struct",
       "name": "CString{:owned}",
       "size": 16,
       "alignment": 8,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 8, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 7, "offset": 8, "isptr": false, "isfieldatomic": false }
       ]
+    },
+    {
+      "id": 9,
+      "kind": "pointer",
+      "name": "Ptr{CString{:owned}}",
+      "pointee_type_id": 8
     },
     {
       "id": 10,
       "kind": "pointer",
-      "name": "Ptr{CString{:owned}}",
-      "pointee_type_id": 9
-    },
-    {
-      "id": 11,
-      "kind": "pointer",
       "name": "Ptr{Nothing}",
       "pointee_type_id": null
     }
-  ]
+]
 }

--- a/JuliaLibWrapping/test/bindinginfo_cdict.json
+++ b/JuliaLibWrapping/test/bindinginfo_cdict.json
@@ -35,21 +35,12 @@
       "pointee_type_id": 3
     },
     {
-      "kind": "primitive",
-      "name": "Int32",
-      "id": 5,
-      "size": 4,
-      "bits": 32,
-      "signed": true,
-      "alignment": 4
-    },
-    {
       "kind": "struct",
       "name": "CString{:borrowed}",
-      "id": 6,
+      "id": 5,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
         { "name": "data", "type_id": 4, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -57,52 +48,52 @@
     {
       "kind": "pointer",
       "name": "Ptr{CString{:borrowed}}",
-      "id": 7,
-      "pointee_type_id": 6
+      "id": 6,
+      "pointee_type_id": 5
     },
     {
       "kind": "pointer",
       "name": "Ptr{Float64}",
-      "id": 8,
+      "id": 7,
       "pointee_type_id": 1
     },
     {
       "kind": "struct",
       "name": "CDict{:borrowed, Float64}",
-      "id": 9,
+      "id": 8,
       "size": 24,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "keys", "type_id": 7, "offset": 8, "isptr": false, "isfieldatomic": false },
-        { "name": "values", "type_id": 8, "offset": 16, "isptr": false, "isfieldatomic": false }
+        { "name": "keys", "type_id": 6, "offset": 8, "isptr": false, "isfieldatomic": false },
+        { "name": "values", "type_id": 7, "offset": 16, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
     {
       "kind": "struct",
       "name": "CDict{:owned, Float64}",
-      "id": 11,
+      "id": 10,
       "size": 24,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "keys", "type_id": 13, "offset": 8, "isptr": false, "isfieldatomic": false },
-        { "name": "values", "type_id": 8, "offset": 16, "isptr": false, "isfieldatomic": false }
+        { "name": "keys", "type_id": 12, "offset": 8, "isptr": false, "isfieldatomic": false },
+        { "name": "values", "type_id": 7, "offset": 16, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
     {
       "kind": "pointer",
       "name": "Ptr{Nothing}",
-      "id": 10,
+      "id": 9,
       "pointee_type_id": null
     },
     {
       "kind": "struct",
       "name": "CString{:owned}",
-      "id": 12,
+      "id": 11,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
         { "name": "data", "type_id": 4, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -110,8 +101,8 @@
     {
       "kind": "pointer",
       "name": "Ptr{CString{:owned}}",
-      "id": 13,
-      "pointee_type_id": 12
+      "id": 12,
+      "pointee_type_id": 11
     }
   ],
   "functions": [
@@ -119,12 +110,12 @@
       "returns": { "type_id": 2 },
       "name": "take_dict(d::CDict{:borrowed, Float64})",
       "arguments": [
-        { "name": "d", "type_id": 9 }
+        { "name": "d", "type_id": 8 }
       ],
       "symbol": "take_dict"
     },
     {
-      "returns": { "type_id": 11 },
+      "returns": { "type_id": 10 },
       "name": "give_dict()",
       "arguments": [],
       "symbol": "give_dict"
@@ -133,7 +124,7 @@
       "returns": { "type_id": null },
       "name": "jlw_free(p::Ptr{Nothing})",
       "arguments": [
-        { "name": "p", "type_id": 10 }
+        { "name": "p", "type_id": 9 }
       ],
       "symbol": "jlw_free"
     },
@@ -141,7 +132,7 @@
       "returns": { "type_id": null },
       "name": "jlw_free_strings(p::Ptr{CString{:owned}}, n::Int64)",
       "arguments": [
-        { "name": "p", "type_id": 13 },
+        { "name": "p", "type_id": 12 },
         { "name": "n", "type_id": 2 }
       ],
       "symbol": "jlw_free_strings"

--- a/JuliaLibWrapping/test/bindinginfo_cdict_int32.json
+++ b/JuliaLibWrapping/test/bindinginfo_cdict_int32.json
@@ -40,7 +40,7 @@
       "id": 5,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 1, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
         { "name": "data", "type_id": 4, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -93,7 +93,7 @@
       "id": 11,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 1, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
         { "name": "data", "type_id": 4, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8

--- a/JuliaLibWrapping/test/bindinginfo_cdict_nofree.json
+++ b/JuliaLibWrapping/test/bindinginfo_cdict_nofree.json
@@ -35,21 +35,12 @@
       "pointee_type_id": 3
     },
     {
-      "kind": "primitive",
-      "name": "Int32",
-      "id": 5,
-      "size": 4,
-      "bits": 32,
-      "signed": true,
-      "alignment": 4
-    },
-    {
       "kind": "struct",
       "name": "CString{:borrowed}",
-      "id": 6,
+      "id": 5,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
         { "name": "data", "type_id": 4, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -57,52 +48,52 @@
     {
       "kind": "pointer",
       "name": "Ptr{CString{:borrowed}}",
-      "id": 7,
-      "pointee_type_id": 6
+      "id": 6,
+      "pointee_type_id": 5
     },
     {
       "kind": "pointer",
       "name": "Ptr{Float64}",
-      "id": 8,
+      "id": 7,
       "pointee_type_id": 1
     },
     {
       "kind": "struct",
       "name": "CDict{:borrowed, Float64}",
-      "id": 9,
+      "id": 8,
       "size": 24,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "keys", "type_id": 7, "offset": 8, "isptr": false, "isfieldatomic": false },
-        { "name": "values", "type_id": 8, "offset": 16, "isptr": false, "isfieldatomic": false }
+        { "name": "keys", "type_id": 6, "offset": 8, "isptr": false, "isfieldatomic": false },
+        { "name": "values", "type_id": 7, "offset": 16, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
     {
       "kind": "struct",
       "name": "CDict{:owned, Float64}",
-      "id": 11,
+      "id": 10,
       "size": 24,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "keys", "type_id": 13, "offset": 8, "isptr": false, "isfieldatomic": false },
-        { "name": "values", "type_id": 8, "offset": 16, "isptr": false, "isfieldatomic": false }
+        { "name": "keys", "type_id": 12, "offset": 8, "isptr": false, "isfieldatomic": false },
+        { "name": "values", "type_id": 7, "offset": 16, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
     {
       "kind": "pointer",
       "name": "Ptr{Nothing}",
-      "id": 10,
+      "id": 9,
       "pointee_type_id": null
     },
     {
       "kind": "struct",
       "name": "CString{:owned}",
-      "id": 12,
+      "id": 11,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
         { "name": "data", "type_id": 4, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -110,8 +101,8 @@
     {
       "kind": "pointer",
       "name": "Ptr{CString{:owned}}",
-      "id": 13,
-      "pointee_type_id": 12
+      "id": 12,
+      "pointee_type_id": 11
     }
   ],
   "functions": [
@@ -119,12 +110,12 @@
       "returns": { "type_id": 2 },
       "name": "take_dict(d::CDict{:borrowed, Float64})",
       "arguments": [
-        { "name": "d", "type_id": 9 }
+        { "name": "d", "type_id": 8 }
       ],
       "symbol": "take_dict"
     },
     {
-      "returns": { "type_id": 11 },
+      "returns": { "type_id": 10 },
       "name": "give_dict()",
       "arguments": [],
       "symbol": "give_dict"

--- a/JuliaLibWrapping/test/bindinginfo_cmatrix.json
+++ b/JuliaLibWrapping/test/bindinginfo_cmatrix.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Hand-authored fixture for the CMatrix vocabulary type (CMatrix{owned,T} = CArray{owned,T,2}). Mirrors the layout juliac emits for `struct CMatrix{:borrowed,Float64}; dims::NTuple{2,Int32}; data::Ptr{Float64}; end` with a single @ccallable function consuming one. The Python emitter must recognize this shape by name + field layout and emit the borrowed-flavored numpy from_numpy/as_numpy helpers (column-major, no free).",
+  "_comment": "Hand-authored fixture for the CMatrix vocabulary type (CMatrix{owned,T} = CArray{owned,T,2}). Mirrors the layout juliac emits for `struct CMatrix{:borrowed,Float64}; dims::NTuple{2,Int64}; data::Ptr{Float64}; end` with a single @ccallable function consuming one. The Python emitter must recognize this shape by name + field layout and emit the borrowed-flavored numpy from_numpy/as_numpy helpers (column-major, no free).",
   "types": [
     {
       "kind": "primitive",
@@ -12,12 +12,12 @@
     },
     {
       "kind": "primitive",
-      "name": "Int32",
+      "name": "Int64",
       "id": 2,
-      "size": 4,
-      "bits": 32,
+      "size": 8,
+      "bits": 64,
       "signed": true,
-      "alignment": 4
+      "alignment": 8
     },
     {
       "kind": "pointer",
@@ -27,21 +27,21 @@
     },
     {
       "kind": "array",
-      "name": "NTuple{2, Int32}",
+      "name": "NTuple{2, Int64}",
       "id": 5,
       "element_type_id": 2,
       "count": 2,
-      "size": 8,
-      "alignment": 4
+      "size": 16,
+      "alignment": 8
     },
     {
       "kind": "struct",
       "name": "CMatrix{:borrowed, Float64}",
       "id": 4,
-      "size": 16,
+      "size": 24,
       "fields": [
         { "name": "dims", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 3, "offset": 16, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     }

--- a/JuliaLibWrapping/test/bindinginfo_cstrarray.json
+++ b/JuliaLibWrapping/test/bindinginfo_cstrarray.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Synthetic fixture for the CStrArray vocabulary type. Mirrors the layout juliac would emit for `struct CStrArray{owned}; length::Int64; data::Ptr{CString{owned}}; end` (JLWInterop), with one @ccallable function taking a `CStrArray{:borrowed}` argument and one returning a `CStrArray{:owned}`, plus the macro-emitted `jlw_free`/`jlw_free_strings` release entrypoints so the owning return is `:auto`, not `:mechanical`. `data` points to length-prefixed `CString` elements (`struct CString{owned}; length::Int32; data::Ptr{UInt8}; end`, size 16, offsets 0/8) rather than NUL-terminated `Ptr{UInt8}`s, and each element carries the container's ownership, so the two containers point at two distinct `CString` structs. Ownership is a leading Symbol type parameter carried in the ABI JSON name, so the two ownerships are two distinct 16-byte structs with an identical `(length, data)` layout. `jlw_free` takes a `Ptr{Nothing}` (a pointer with a null pointee id) and both release entrypoints return void (a null return type id), mirroring juliac's actual ABI JSON rendering. The Python emitter must recognize the CStrArray shape (ownership token in the name + pointee-is-CString shape, not just the name) and emit `from_list`/`as_list` on the borrowed class, `as_list`/`free` on the owning class, and an owning-return convert-then-free facade wrapper.",
+  "_comment": "Synthetic fixture for the CStrArray vocabulary type. Mirrors the layout juliac would emit for `struct CStrArray{owned}; length::Int64; data::Ptr{CString{owned}}; end` (JLWInterop), with one @ccallable function taking a `CStrArray{:borrowed}` argument and one returning a `CStrArray{:owned}`, plus the macro-emitted `jlw_free`/`jlw_free_strings` release entrypoints so the owning return is `:auto`, not `:mechanical`. `data` points to length-prefixed `CString` elements (`struct CString{owned}; length::Int64; data::Ptr{UInt8}; end`, size 16, offsets 0/8) rather than NUL-terminated `Ptr{UInt8}`s, and each element carries the container's ownership, so the two containers point at two distinct `CString` structs. Ownership is a leading Symbol type parameter carried in the ABI JSON name, so the two ownerships are two distinct 16-byte structs with an identical `(length, data)` layout. `jlw_free` takes a `Ptr{Nothing}` (a pointer with a null pointee id) and both release entrypoints return void (a null return type id), mirroring juliac's actual ABI JSON rendering. The Python emitter must recognize the CStrArray shape (ownership token in the name + pointee-is-CString shape, not just the name) and emit `from_list`/`as_list` on the borrowed class, `as_list`/`free` on the owning class, and an owning-return convert-then-free facade wrapper.",
   "types": [
     {
       "kind": "primitive",
@@ -26,21 +26,12 @@
       "pointee_type_id": 1
     },
     {
-      "kind": "primitive",
-      "name": "Int32",
-      "id": 4,
-      "size": 4,
-      "bits": 32,
-      "signed": true,
-      "alignment": 4
-    },
-    {
       "kind": "struct",
       "name": "CString{:borrowed}",
-      "id": 5,
+      "id": 4,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 4, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
         { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -48,44 +39,44 @@
     {
       "kind": "pointer",
       "name": "Ptr{CString{:borrowed}}",
-      "id": 6,
-      "pointee_type_id": 5
+      "id": 5,
+      "pointee_type_id": 4
     },
     {
       "kind": "struct",
       "name": "CStrArray{:borrowed}",
-      "id": 7,
+      "id": 6,
       "size": 16,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 6, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 5, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
     {
       "kind": "struct",
       "name": "CStrArray{:owned}",
-      "id": 9,
+      "id": 8,
       "size": 16,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 11, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 10, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
     {
       "kind": "pointer",
       "name": "Ptr{Nothing}",
-      "id": 8,
+      "id": 7,
       "pointee_type_id": null
     },
     {
       "kind": "struct",
       "name": "CString{:owned}",
-      "id": 10,
+      "id": 9,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 4, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
         { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -93,8 +84,8 @@
     {
       "kind": "pointer",
       "name": "Ptr{CString{:owned}}",
-      "id": 11,
-      "pointee_type_id": 10
+      "id": 10,
+      "pointee_type_id": 9
     }
   ],
   "functions": [
@@ -102,12 +93,12 @@
       "returns": { "type_id": 2 },
       "name": "take_strs(a::CStrArray{:borrowed})",
       "arguments": [
-        { "name": "a", "type_id": 7 }
+        { "name": "a", "type_id": 6 }
       ],
       "symbol": "take_strs"
     },
     {
-      "returns": { "type_id": 9 },
+      "returns": { "type_id": 8 },
       "name": "give_strs()",
       "arguments": [],
       "symbol": "give_strs"
@@ -116,7 +107,7 @@
       "returns": { "type_id": null },
       "name": "jlw_free(p::Ptr{Nothing})",
       "arguments": [
-        { "name": "p", "type_id": 8 }
+        { "name": "p", "type_id": 7 }
       ],
       "symbol": "jlw_free"
     },
@@ -124,7 +115,7 @@
       "returns": { "type_id": null },
       "name": "jlw_free_strings(p::Ptr{CString{:owned}}, n::Int64)",
       "arguments": [
-        { "name": "p", "type_id": 11 },
+        { "name": "p", "type_id": 10 },
         { "name": "n", "type_id": 2 }
       ],
       "symbol": "jlw_free_strings"

--- a/JuliaLibWrapping/test/bindinginfo_cstrarray_nofree.json
+++ b/JuliaLibWrapping/test/bindinginfo_cstrarray_nofree.json
@@ -26,21 +26,12 @@
       "pointee_type_id": 1
     },
     {
-      "kind": "primitive",
-      "name": "Int32",
-      "id": 4,
-      "size": 4,
-      "bits": 32,
-      "signed": true,
-      "alignment": 4
-    },
-    {
       "kind": "struct",
       "name": "CString{:borrowed}",
-      "id": 5,
+      "id": 4,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 4, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
         { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -48,44 +39,44 @@
     {
       "kind": "pointer",
       "name": "Ptr{CString{:borrowed}}",
-      "id": 6,
-      "pointee_type_id": 5
+      "id": 5,
+      "pointee_type_id": 4
     },
     {
       "kind": "struct",
       "name": "CStrArray{:borrowed}",
-      "id": 7,
+      "id": 6,
       "size": 16,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 6, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 5, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
     {
       "kind": "struct",
       "name": "CStrArray{:owned}",
-      "id": 9,
+      "id": 8,
       "size": 16,
       "fields": [
         { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 11, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "data", "type_id": 10, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
     {
       "kind": "pointer",
       "name": "Ptr{Nothing}",
-      "id": 8,
+      "id": 7,
       "pointee_type_id": null
     },
     {
       "kind": "struct",
       "name": "CString{:owned}",
-      "id": 10,
+      "id": 9,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 4, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
         { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
@@ -93,8 +84,8 @@
     {
       "kind": "pointer",
       "name": "Ptr{CString{:owned}}",
-      "id": 11,
-      "pointee_type_id": 10
+      "id": 10,
+      "pointee_type_id": 9
     }
   ],
   "functions": [
@@ -102,12 +93,12 @@
       "returns": { "type_id": 2 },
       "name": "take_strs(a::CStrArray{:borrowed})",
       "arguments": [
-        { "name": "a", "type_id": 7 }
+        { "name": "a", "type_id": 6 }
       ],
       "symbol": "take_strs"
     },
     {
-      "returns": { "type_id": 9 },
+      "returns": { "type_id": 8 },
       "name": "give_strs()",
       "arguments": [],
       "symbol": "give_strs"

--- a/JuliaLibWrapping/test/bindinginfo_cstring.json
+++ b/JuliaLibWrapping/test/bindinginfo_cstring.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Hand-authored fixture for a borrowed CString. Mirrors the layout juliac would emit for `struct CString{owned}; length::Int32; data::Ptr{UInt8}; end` instantiated at :borrowed, with one @ccallable function consuming a `CString{:borrowed}` and one returning one. Ownership is a leading Symbol type parameter carried in the ABI JSON name, and a name that states no ownership is not recognized at all. The Python emitter must recognize this shape by name + field layout and emit from_str / as_str / from_bytes / as_bytes helpers and no free(): the buffer belongs to the caller, so the facade converts str in and str out and releases nothing.",
+  "_comment": "Hand-authored fixture for a borrowed CString. Mirrors the layout juliac would emit for `struct CString{owned}; length::Int64; data::Ptr{UInt8}; end` instantiated at :borrowed, with one @ccallable function consuming a `CString{:borrowed}` and one returning one. Ownership is a leading Symbol type parameter carried in the ABI JSON name, and a name that states no ownership is not recognized at all. The Python emitter must recognize this shape by name + field layout and emit from_str / as_str / from_bytes / as_bytes helpers and no free(): the buffer belongs to the caller, so the facade converts str in and str out and releases nothing.",
   "types": [
     {
       "kind": "primitive",
@@ -31,9 +31,18 @@
       "id": 4,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "length", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
         { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
+      "alignment": 8
+    },
+    {
+      "kind": "primitive",
+      "name": "Int64",
+      "id": 5,
+      "size": 8,
+      "bits": 64,
+      "signed": true,
       "alignment": 8
     }
   ],

--- a/JuliaLibWrapping/test/bindinginfo_cstring_owned.json
+++ b/JuliaLibWrapping/test/bindinginfo_cstring_owned.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Hand-authored fixture for an owning CString return. Mirrors the layout juliac would emit for `struct CString{owned}; length::Int32; data::Ptr{UInt8}; end` instantiated at :owned, with one @ccallable function returning a freshly allocated `CString{:owned}`, plus the macro-emitted jlw_free/jlw_free_strings release entrypoints so the owning return is `:auto` (decode, then free in a `finally`), not `:mechanical`. The two ownerships are two distinct 16-byte structs with an identical `(length, data)` layout, so only the name distinguishes them; bindinginfo_cstring.json covers the borrowed side. `jlw_free` takes a `Ptr{Nothing}` (a pointer with a null pointee id) and both release entrypoints return void (a null return type id), mirroring juliac's actual ABI JSON rendering. The Python emitter must emit as_str/as_bytes and an idempotent free() on the owning class, and no from_str/from_bytes: Python has no Julia allocation to hand over.",
+  "_comment": "Hand-authored fixture for an owning CString return. Mirrors the layout juliac would emit for `struct CString{owned}; length::Int64; data::Ptr{UInt8}; end` instantiated at :owned, with one @ccallable function returning a freshly allocated `CString{:owned}`, plus the macro-emitted jlw_free/jlw_free_strings release entrypoints so the owning return is `:auto` (decode, then free in a `finally`), not `:mechanical`. The two ownerships are two distinct 16-byte structs with an identical `(length, data)` layout, so only the name distinguishes them; bindinginfo_cstring.json covers the borrowed side. `jlw_free` takes a `Ptr{Nothing}` (a pointer with a null pointee id) and both release entrypoints return void (a null return type id), mirroring juliac's actual ABI JSON rendering. The Python emitter must emit as_str/as_bytes and an idempotent free() on the owning class, and no from_str/from_bytes: Python has no Julia allocation to hand over.",
   "types": [
     {
       "kind": "primitive",
@@ -11,41 +11,32 @@
       "alignment": 1
     },
     {
-      "kind": "primitive",
-      "name": "Int32",
-      "id": 2,
-      "size": 4,
-      "bits": 32,
-      "signed": true,
-      "alignment": 4
-    },
-    {
       "kind": "pointer",
       "name": "Ptr{UInt8}",
-      "id": 3,
+      "id": 2,
       "pointee_type_id": 1
     },
     {
       "kind": "struct",
       "name": "CString{:owned}",
-      "id": 4,
+      "id": 3,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "length", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "data", "type_id": 2, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
     {
       "kind": "pointer",
       "name": "Ptr{CString{:owned}}",
-      "id": 5,
-      "pointee_type_id": 4
+      "id": 4,
+      "pointee_type_id": 3
     },
     {
       "kind": "primitive",
       "name": "Int64",
-      "id": 6,
+      "id": 5,
       "size": 8,
       "bits": 64,
       "signed": true,
@@ -54,13 +45,13 @@
     {
       "kind": "pointer",
       "name": "Ptr{Nothing}",
-      "id": 7,
+      "id": 6,
       "pointee_type_id": null
     }
   ],
   "functions": [
     {
-      "returns": { "type_id": 4 },
+      "returns": { "type_id": 3 },
       "name": "give_greeting()",
       "arguments": [],
       "symbol": "give_greeting"
@@ -69,7 +60,7 @@
       "returns": { "type_id": null },
       "name": "jlw_free(p::Ptr{Nothing})",
       "arguments": [
-        { "name": "p", "type_id": 7 }
+        { "name": "p", "type_id": 6 }
       ],
       "symbol": "jlw_free"
     },
@@ -77,8 +68,8 @@
       "returns": { "type_id": null },
       "name": "jlw_free_strings(p::Ptr{CString{:owned}}, n::Int64)",
       "arguments": [
-        { "name": "p", "type_id": 5 },
-        { "name": "n", "type_id": 6 }
+        { "name": "p", "type_id": 4 },
+        { "name": "n", "type_id": 5 }
       ],
       "symbol": "jlw_free_strings"
     }

--- a/JuliaLibWrapping/test/bindinginfo_cstring_owned_nofree.json
+++ b/JuliaLibWrapping/test/bindinginfo_cstring_owned_nofree.json
@@ -11,41 +11,32 @@
       "alignment": 1
     },
     {
-      "kind": "primitive",
-      "name": "Int32",
-      "id": 2,
-      "size": 4,
-      "bits": 32,
-      "signed": true,
-      "alignment": 4
-    },
-    {
       "kind": "pointer",
       "name": "Ptr{UInt8}",
-      "id": 3,
+      "id": 2,
       "pointee_type_id": 1
     },
     {
       "kind": "struct",
       "name": "CString{:owned}",
-      "id": 4,
+      "id": 3,
       "size": 16,
       "fields": [
-        { "name": "length", "type_id": 2, "offset": 0, "isptr": false, "isfieldatomic": false },
-        { "name": "data", "type_id": 3, "offset": 8, "isptr": false, "isfieldatomic": false }
+        { "name": "length", "type_id": 5, "offset": 0, "isptr": false, "isfieldatomic": false },
+        { "name": "data", "type_id": 2, "offset": 8, "isptr": false, "isfieldatomic": false }
       ],
       "alignment": 8
     },
     {
       "kind": "pointer",
       "name": "Ptr{CString{:owned}}",
-      "id": 5,
-      "pointee_type_id": 4
+      "id": 4,
+      "pointee_type_id": 3
     },
     {
       "kind": "primitive",
       "name": "Int64",
-      "id": 6,
+      "id": 5,
       "size": 8,
       "bits": 64,
       "signed": true,
@@ -54,13 +45,13 @@
     {
       "kind": "pointer",
       "name": "Ptr{Nothing}",
-      "id": 7,
+      "id": 6,
       "pointee_type_id": null
     }
   ],
   "functions": [
     {
-      "returns": { "type_id": 4 },
+      "returns": { "type_id": 3 },
       "name": "give_greeting()",
       "arguments": [],
       "symbol": "give_greeting"

--- a/JuliaLibWrapping/test/bindinginfo_libsimple.json
+++ b/JuliaLibWrapping/test/bindinginfo_libsimple.json
@@ -138,11 +138,11 @@
     {
       "id": 13,
       "kind": "array",
-      "name": "NTuple{1, Int32}",
-      "element_type_id": 4,
+      "name": "NTuple{1, Int64}",
+      "element_type_id": 6,
       "count": 1,
-      "size": 4,
-      "alignment": 4
+      "size": 8,
+      "alignment": 8
     }
   ]
 }

--- a/JuliaLibWrapping/test/expected_api_scale_facade.py
+++ b/JuliaLibWrapping/test/expected_api_scale_facade.py
@@ -17,12 +17,12 @@ from . import _lowlevel  # noqa: F401
 import numpy as np  # noqa: F401
 
 from ._lowlevel import (
-    JLWStatus,
     CVector_borrowed_Float64,
     CVector_owned_Float64,
-    JLWResult_CVector_owned_Float64,
     CString_borrowed,
     CString_owned,
+    JLWStatus,
+    JLWResult_CVector_owned_Float64,
     JLWError,
 )
 
@@ -39,4 +39,4 @@ def scale(x, *, factor=2.0, label):
         _r.value.free()
     return _out
 
-__all__ = ["JLWStatus", "CVector_borrowed_Float64", "CVector_owned_Float64", "JLWResult_CVector_owned_Float64", "CString_borrowed", "CString_owned", "JLWError", "scale"]
+__all__ = ["CVector_borrowed_Float64", "CVector_owned_Float64", "CString_borrowed", "CString_owned", "JLWStatus", "JLWResult_CVector_owned_Float64", "JLWError", "scale"]

--- a/JuliaLibWrapping/test/expected_api_scale_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_api_scale_lowlevel.py
@@ -61,15 +61,9 @@ class JLWError(RuntimeError):
         self.code = code
         self.message = message
 
-class JLWStatus(ctypes.Structure):
-    _fields_ = [
-        ("code", ctypes.c_int32),
-        ("message", (ctypes.c_uint8 * 256)),
-    ]
-
 class CVector_borrowed_Float64(ctypes.Structure):
     _fields_ = [
-        ("dims", (ctypes.c_int32 * 1)),
+        ("dims", (ctypes.c_int64 * 1)),
         ("data", ctypes.POINTER(ctypes.c_double)),
     ]
 
@@ -88,7 +82,7 @@ class CVector_borrowed_Float64(ctypes.Structure):
         expected_dtype = np.dtype("float64")
         if arr.dtype != expected_dtype:
             raise ValueError(f"expected dtype float64, got {arr.dtype}")
-        obj = cls(dims=(ctypes.c_int32 * 1)(*arr.shape),
+        obj = cls(dims=(ctypes.c_int64 * 1)(*arr.shape),
                   data=arr.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
         obj._buffer = arr
         return obj
@@ -99,7 +93,7 @@ class CVector_borrowed_Float64(ctypes.Structure):
 
 class CVector_owned_Float64(ctypes.Structure):
     _fields_ = [
-        ("dims", (ctypes.c_int32 * 1)),
+        ("dims", (ctypes.c_int64 * 1)),
         ("data", ctypes.POINTER(ctypes.c_double)),
     ]
 
@@ -128,15 +122,9 @@ class CVector_owned_Float64(ctypes.Structure):
         self.data = type(self.data)()
         self.dims = type(self.dims)()
 
-class JLWResult_CVector_owned_Float64(ctypes.Structure):
-    _fields_ = [
-        ("status", JLWStatus),
-        ("value", CVector_owned_Float64),
-    ]
-
 class CString_borrowed(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 
@@ -173,7 +161,7 @@ class CString_borrowed(ctypes.Structure):
 
 class CString_owned(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 
@@ -207,6 +195,18 @@ class CString_owned(ctypes.Structure):
         _lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))
         self.data = type(self.data)()
         self.length = 0
+
+class JLWStatus(ctypes.Structure):
+    _fields_ = [
+        ("code", ctypes.c_int32),
+        ("message", (ctypes.c_uint8 * 256)),
+    ]
+
+class JLWResult_CVector_owned_Float64(ctypes.Structure):
+    _fields_ = [
+        ("status", JLWStatus),
+        ("value", CVector_owned_Float64),
+    ]
 
 _lib.mylib_scale.argtypes = [CVector_borrowed_Float64, ctypes.c_double, CString_borrowed]
 _lib.mylib_scale.restype = JLWResult_CVector_owned_Float64

--- a/JuliaLibWrapping/test/expected_carray3_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_carray3_lowlevel.py
@@ -56,7 +56,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CArray_borrowed_Float64_3(ctypes.Structure):
     _fields_ = [
-        ("dims", (ctypes.c_int32 * 3)),
+        ("dims", (ctypes.c_int64 * 3)),
         ("data", ctypes.POINTER(ctypes.c_double)),
     ]
 
@@ -78,7 +78,7 @@ class CArray_borrowed_Float64_3(ctypes.Structure):
         expected_dtype = np.dtype("float64")
         if arr.dtype != expected_dtype:
             raise ValueError(f"expected dtype float64, got {arr.dtype}")
-        obj = cls(dims=(ctypes.c_int32 * 3)(*arr.shape),
+        obj = cls(dims=(ctypes.c_int64 * 3)(*arr.shape),
                   data=arr.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
         obj._buffer = arr
         return obj

--- a/JuliaLibWrapping/test/expected_carray_owned_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_carray_owned_lowlevel.py
@@ -56,7 +56,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CString_owned(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 
@@ -93,7 +93,7 @@ class CString_owned(ctypes.Structure):
 
 class CVector_owned_Float64(ctypes.Structure):
     _fields_ = [
-        ("dims", (ctypes.c_int32 * 1)),
+        ("dims", (ctypes.c_int64 * 1)),
         ("data", ctypes.POINTER(ctypes.c_double)),
     ]
 

--- a/JuliaLibWrapping/test/expected_carray_owned_nofree_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_carray_owned_nofree_lowlevel.py
@@ -56,7 +56,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CString_owned(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 
@@ -88,7 +88,7 @@ class CString_owned(ctypes.Structure):
 
 class CVector_owned_Float64(ctypes.Structure):
     _fields_ = [
-        ("dims", (ctypes.c_int32 * 1)),
+        ("dims", (ctypes.c_int64 * 1)),
         ("data", ctypes.POINTER(ctypes.c_double)),
     ]
 

--- a/JuliaLibWrapping/test/expected_cdict_int32_facade.py
+++ b/JuliaLibWrapping/test/expected_cdict_int32_facade.py
@@ -17,8 +17,8 @@ from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
     CString_borrowed,
-    CDict_borrowed_Int32,
     CString_owned,
+    CDict_borrowed_Int32,
     CDict_owned_Int32,
 )
 
@@ -34,4 +34,4 @@ def give_dict_i32():
         _result.free()
     return _out
 
-__all__ = ["CString_borrowed", "CDict_borrowed_Int32", "CString_owned", "CDict_owned_Int32", "take_dict_i32", "give_dict_i32"]
+__all__ = ["CString_borrowed", "CString_owned", "CDict_borrowed_Int32", "CDict_owned_Int32", "take_dict_i32", "give_dict_i32"]

--- a/JuliaLibWrapping/test/expected_cdict_int32_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cdict_int32_lowlevel.py
@@ -55,7 +55,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CString_borrowed(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 
@@ -90,36 +90,9 @@ class CString_borrowed(ctypes.Structure):
         """Return the underlying bytes decoded as UTF-8."""
         return self.as_bytes().decode("utf-8")
 
-class CDict_borrowed_Int32(ctypes.Structure):
-    _fields_ = [
-        ("length", ctypes.c_int64),
-        ("keys", ctypes.POINTER(CString_borrowed)),
-        ("values", ctypes.POINTER(ctypes.c_int32)),
-    ]
-
-    @classmethod
-    def from_dict(cls, d):
-        keys = [k.encode("utf-8") for k in d.keys()]
-        karr = (CString_borrowed * len(keys))(
-            *[CString_borrowed(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in keys])
-        varr = (ctypes.c_int32 * len(keys))(*d.values())
-        obj = cls(length=len(keys),
-                  keys=ctypes.cast(karr, ctypes.POINTER(CString_borrowed)),
-                  values=ctypes.cast(varr, ctypes.POINTER(ctypes.c_int32)))
-        obj._buffer = (keys, karr, varr)
-        return obj
-
-    def as_dict(self):
-        out = {}
-        for i in range(self.length):
-            e = self.keys[i]
-            k = ctypes.string_at(e.data, e.length).decode("utf-8")
-            out[k] = self.values[i]
-        return out
-
 class CString_owned(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 
@@ -153,6 +126,33 @@ class CString_owned(ctypes.Structure):
         _lib.jlw_free(ctypes.cast(self.data, ctypes.c_void_p))
         self.data = type(self.data)()
         self.length = 0
+
+class CDict_borrowed_Int32(ctypes.Structure):
+    _fields_ = [
+        ("length", ctypes.c_int64),
+        ("keys", ctypes.POINTER(CString_borrowed)),
+        ("values", ctypes.POINTER(ctypes.c_int32)),
+    ]
+
+    @classmethod
+    def from_dict(cls, d):
+        keys = [k.encode("utf-8") for k in d.keys()]
+        karr = (CString_borrowed * len(keys))(
+            *[CString_borrowed(length=len(b), data=ctypes.cast(ctypes.create_string_buffer(b, len(b)), ctypes.POINTER(ctypes.c_uint8))) for b in keys])
+        varr = (ctypes.c_int32 * len(keys))(*d.values())
+        obj = cls(length=len(keys),
+                  keys=ctypes.cast(karr, ctypes.POINTER(CString_borrowed)),
+                  values=ctypes.cast(varr, ctypes.POINTER(ctypes.c_int32)))
+        obj._buffer = (keys, karr, varr)
+        return obj
+
+    def as_dict(self):
+        out = {}
+        for i in range(self.length):
+            e = self.keys[i]
+            k = ctypes.string_at(e.data, e.length).decode("utf-8")
+            out[k] = self.values[i]
+        return out
 
 class CDict_owned_Int32(ctypes.Structure):
     _fields_ = [

--- a/JuliaLibWrapping/test/expected_cdict_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cdict_lowlevel.py
@@ -55,7 +55,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CString_borrowed(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 
@@ -92,7 +92,7 @@ class CString_borrowed(ctypes.Structure):
 
 class CString_owned(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 

--- a/JuliaLibWrapping/test/expected_cdict_nofree_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cdict_nofree_lowlevel.py
@@ -55,7 +55,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CString_borrowed(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 
@@ -92,7 +92,7 @@ class CString_borrowed(ctypes.Structure):
 
 class CString_owned(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 

--- a/JuliaLibWrapping/test/expected_cmatrix_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cmatrix_lowlevel.py
@@ -56,7 +56,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CMatrix_borrowed_Float64(ctypes.Structure):
     _fields_ = [
-        ("dims", (ctypes.c_int32 * 2)),
+        ("dims", (ctypes.c_int64 * 2)),
         ("data", ctypes.POINTER(ctypes.c_double)),
     ]
 
@@ -78,7 +78,7 @@ class CMatrix_borrowed_Float64(ctypes.Structure):
         expected_dtype = np.dtype("float64")
         if arr.dtype != expected_dtype:
             raise ValueError(f"expected dtype float64, got {arr.dtype}")
-        obj = cls(dims=(ctypes.c_int32 * 2)(*arr.shape),
+        obj = cls(dims=(ctypes.c_int64 * 2)(*arr.shape),
                   data=arr.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
         obj._buffer = arr
         return obj

--- a/JuliaLibWrapping/test/expected_cstrarray_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cstrarray_lowlevel.py
@@ -55,7 +55,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CString_borrowed(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 
@@ -116,7 +116,7 @@ class CStrArray_borrowed(ctypes.Structure):
 
 class CString_owned(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 

--- a/JuliaLibWrapping/test/expected_cstrarray_nofree_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cstrarray_nofree_lowlevel.py
@@ -55,7 +55,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CString_borrowed(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 
@@ -116,7 +116,7 @@ class CStrArray_borrowed(ctypes.Structure):
 
 class CString_owned(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 

--- a/JuliaLibWrapping/test/expected_cstring_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cstring_lowlevel.py
@@ -55,7 +55,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CString_borrowed(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 

--- a/JuliaLibWrapping/test/expected_cstring_owned_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cstring_owned_lowlevel.py
@@ -55,7 +55,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CString_owned(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 

--- a/JuliaLibWrapping/test/expected_cstring_owned_nofree_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_cstring_owned_nofree_lowlevel.py
@@ -55,7 +55,7 @@ _jlw_loaded.add(_jlw_this_pkg)
 
 class CString_owned(ctypes.Structure):
     _fields_ = [
-        ("length", ctypes.c_int32),
+        ("length", ctypes.c_int64),
         ("data", ctypes.POINTER(ctypes.c_uint8)),
     ]
 

--- a/JuliaLibWrapping/test/expected_libsimple_facade.py
+++ b/JuliaLibWrapping/test/expected_libsimple_facade.py
@@ -16,9 +16,9 @@ on every `write_wrapper` call.
 from . import _lowlevel  # noqa: F401
 
 from ._lowlevel import (
-    MyTwoVec,
     CVector_borrowed_Float32,
     CVectorPair_Float32,
+    MyTwoVec,
     CVector_borrowed_CTree_Float64,
     CTree_Float64,
 )
@@ -27,4 +27,4 @@ from ._lowlevel import tree_size  # TODO: hand-wrap — `tree`: argument has unr
 from ._lowlevel import copyto_and_sum  # TODO: hand-wrap — `fromto`: argument has unrecognized type `CVectorPair{Float32}`
 from ._lowlevel import countsame  # TODO: hand-wrap — `list`: argument has raw pointer type `Ptr{MyTwoVec}`
 
-__all__ = ["MyTwoVec", "CVector_borrowed_Float32", "CVectorPair_Float32", "CVector_borrowed_CTree_Float64", "CTree_Float64", "tree_size", "copyto_and_sum", "countsame"]
+__all__ = ["CVector_borrowed_Float32", "CVectorPair_Float32", "MyTwoVec", "CVector_borrowed_CTree_Float64", "CTree_Float64", "tree_size", "copyto_and_sum", "countsame"]

--- a/JuliaLibWrapping/test/expected_libsimple_lowlevel.py
+++ b/JuliaLibWrapping/test/expected_libsimple_lowlevel.py
@@ -58,15 +58,9 @@ _jlw_loaded.add(_jlw_this_pkg)
 class CTree_Float64(ctypes.Structure):
     pass
 
-class MyTwoVec(ctypes.Structure):
-    _fields_ = [
-        ("x", ctypes.c_int32),
-        ("y", ctypes.c_int32),
-    ]
-
 class CVector_borrowed_Float32(ctypes.Structure):
     _fields_ = [
-        ("dims", (ctypes.c_int32 * 1)),
+        ("dims", (ctypes.c_int64 * 1)),
         ("data", ctypes.POINTER(ctypes.c_float)),
     ]
 
@@ -85,7 +79,7 @@ class CVector_borrowed_Float32(ctypes.Structure):
         expected_dtype = np.dtype("float32")
         if arr.dtype != expected_dtype:
             raise ValueError(f"expected dtype float32, got {arr.dtype}")
-        obj = cls(dims=(ctypes.c_int32 * 1)(*arr.shape),
+        obj = cls(dims=(ctypes.c_int64 * 1)(*arr.shape),
                   data=arr.ctypes.data_as(ctypes.POINTER(ctypes.c_float)))
         obj._buffer = arr
         return obj
@@ -100,9 +94,15 @@ class CVectorPair_Float32(ctypes.Structure):
         ("to", CVector_borrowed_Float32),
     ]
 
+class MyTwoVec(ctypes.Structure):
+    _fields_ = [
+        ("x", ctypes.c_int32),
+        ("y", ctypes.c_int32),
+    ]
+
 class CVector_borrowed_CTree_Float64(ctypes.Structure):
     _fields_ = [
-        ("dims", (ctypes.c_int32 * 1)),
+        ("dims", (ctypes.c_int64 * 1)),
         ("data", ctypes.POINTER(CTree_Float64)),
     ]
 

--- a/JuliaLibWrapping/test/runtests.jl
+++ b/JuliaLibWrapping/test/runtests.jl
@@ -70,7 +70,7 @@ end
         dims_desc = typeinfo[tdesc.fields[1].type]
         @test dims_desc isa ArrayDesc
         @test dims_desc.count == 1
-        @test typeinfo[dims_desc.element_type].name == "Int32"
+        @test typeinfo[dims_desc.element_type].name == "Int64"
         @test iszero(tdesc.fields[1].offset)
         @test tdesc.fields[2].name == "data"
         @test typeinfo[tdesc.fields[2].type].name == "Ptr{Float32}"
@@ -290,7 +290,7 @@ end
             @test occursin("#include <stdint.h>", content)
             @test occursin("#include <stdbool.h>", content)
             @test occursin("typedef struct CVector_borrowed_Float32 {", content)
-            @test occursin("    int32_t dims[1];", content)
+            @test occursin("    int64_t dims[1];", content)
             @test occursin("    float* data;", content)
             @test occursin("CVector_borrowed_Float32 from;", content)
             @test occursin("CVector_borrowed_Float32 to;", content)
@@ -376,7 +376,7 @@ end
             @test occursin("_LIBRARY_ENV_VAR = \"LIBSIMPLE_LIBRARY\"", bindings)
             @test occursin("class CTree_Float64(ctypes.Structure):\n    pass", bindings)
             @test occursin("class CVector_borrowed_Float32(ctypes.Structure):", bindings)
-            @test occursin("(\"dims\", (ctypes.c_int32 * 1))", bindings)
+            @test occursin("(\"dims\", (ctypes.c_int64 * 1))", bindings)
             @test occursin("(\"data\", ctypes.POINTER(ctypes.c_float))", bindings)
             # `from` is a Python keyword; it must be renamed to be reachable
             # via attribute access.
@@ -680,7 +680,7 @@ end
         # three-field pre-type-parameter layout. Plus a Bool-pointee CArray,
         # which is a structural match the Python adapter declines.
         primint = PrimitiveTypeDesc("Int32", true, 32, 4, 4)
-        primflt = PrimitiveTypeDesc("Float32", true, 32, 4, 4)
+        primflt = PrimitiveTypeDesc("Float32", false, 32, 4, 4)
         primbool = PrimitiveTypeDesc("Bool", false, 8, 1, 1)
         ptr_to_flt = PointerDesc("Ptr{Float32}", 2)
         arr_int32_1 = ArrayDesc("NTuple{1, Int32}", 1, 1, 4, 4)
@@ -1190,9 +1190,8 @@ end
 
     @testset "copt_struct_info" begin
         # Structural recognition of the COpt{T} shape: a struct named COpt
-        # with `has_value` (Int32 primitive) and `value` (any primitive)
-        # fields. The recognizer reports T's Julia name; `_python_copt_info`
-        # decides whether it is a supported payload type.
+        # with a signed 32- or 64-bit `has_value` and primitive `value`.
+        # `_python_copt_info` filters unsupported payload types.
         coinfo(desc, typeinfo) = JuliaLibWrapping.copt_struct_info(desc, typeinfo)
         pycoinfo(desc, typeinfo) = JuliaLibWrapping._python_copt_info(desc, typeinfo)
         abi = read_abi_info("bindinginfo_copt.json")
@@ -1229,7 +1228,7 @@ end
             ),
             7 => StructDesc(
                 "COptInt64HasValue", 16, 8, FieldDesc[
-                    FieldDesc("has_value", 2, 0),  # Int64 — not Int32
+                    FieldDesc("has_value", 2, 0),
                     FieldDesc("value", 3, 8),
                 ]
             ),
@@ -1265,7 +1264,7 @@ end
         )
         @test !isnothing(coinfo(ti[5], ti))
         @test isnothing(coinfo(ti[6], ti)) # wrong name prefix
-        @test isnothing(coinfo(ti[7], ti)) # has_value is Int64, not Int32
+        @test !isnothing(coinfo(ti[7], ti))
         @test isnothing(coinfo(ti[8], ti)) # wrong field names
         @test !isnothing(coinfo(ti[9], ti)) # value is a primitive: a structural match
         @test coinfo(ti[9], ti).value_type == "NotARealType"
@@ -1283,6 +1282,166 @@ end
             ]
         )
         @test !isnothing(coinfo(flipped, ti))
+    end
+
+    @testset "integer field width policy" begin
+        widths = (
+            Int32 = PrimitiveTypeDesc("Int32", true, 32, 4, 4),
+            Int64 = PrimitiveTypeDesc("Int64", true, 64, 8, 8),
+            Int16 = PrimitiveTypeDesc("Int16", true, 16, 2, 2),
+            UInt64 = PrimitiveTypeDesc("UInt64", false, 64, 8, 8),
+        )
+        accepted = (Int32 = true, Int64 = true, Int16 = false, UInt64 = false)
+        for name in keys(widths)
+            prim = widths[name]
+            # Keep the element CString at Int64 to isolate the container field.
+            ti = OrderedDict{Int, TypeDesc}(
+                1 => prim,
+                2 => PrimitiveTypeDesc("UInt8", false, 8, 1, 1),
+                3 => PrimitiveTypeDesc("Float64", false, 64, 8, 8),
+                4 => PointerDesc("Ptr{UInt8}", 2),
+                5 => PointerDesc("Ptr{Float64}", 3),
+                6 => PrimitiveTypeDesc("Int64", true, 64, 8, 8),
+                7 => StructDesc(
+                    "CString{:borrowed}", 16, 8, FieldDesc[
+                        FieldDesc("length", 1, 0),
+                        FieldDesc("data", 4, 8),
+                    ]
+                ),
+                8 => StructDesc(
+                    "CString{:borrowed}", 16, 8, FieldDesc[
+                        FieldDesc("length", 6, 0),
+                        FieldDesc("data", 4, 8),
+                    ]
+                ),
+                9 => PointerDesc("Ptr{CString{:borrowed}}", 8),
+                10 => ArrayDesc("NTuple{1, $name}", 1, 1, prim.size, prim.alignment),
+                11 => StructDesc(
+                    "CVector{:borrowed, Float64}", 16, 8, FieldDesc[
+                        FieldDesc("dims", 10, 0),
+                        FieldDesc("data", 5, 8),
+                    ]
+                ),
+                12 => StructDesc(
+                    "CStrArray{:borrowed}", 16, 8, FieldDesc[
+                        FieldDesc("length", 1, 0),
+                        FieldDesc("data", 9, 8),
+                    ]
+                ),
+                13 => StructDesc(
+                    "CDict{:borrowed, Float64}", 24, 8, FieldDesc[
+                        FieldDesc("length", 1, 0),
+                        FieldDesc("keys", 9, 8),
+                        FieldDesc("values", 5, 16),
+                    ]
+                ),
+                14 => StructDesc(
+                    "COpt{Float64}", 16, 8, FieldDesc[
+                        FieldDesc("has_value", 1, 0),
+                        FieldDesc("value", 3, 8),
+                    ]
+                ),
+                15 => ArrayDesc("NTuple{256, UInt8}", 2, 256, 256, 1),
+                16 => StructDesc(
+                    "JLWStatus", 264, 8, FieldDesc[
+                        FieldDesc("code", 1, 0),
+                        FieldDesc("message", 15, 4),
+                    ]
+                ),
+            )
+            ok = accepted[name]
+            @test !isnothing(JuliaLibWrapping.cstring_struct_info(ti[7], ti)) == ok
+            @test !isnothing(JuliaLibWrapping.carray_struct_info(ti[11], ti)) == ok
+            @test !isnothing(JuliaLibWrapping.cstrarray_struct_info(ti[12], ti)) == ok
+            @test !isnothing(JuliaLibWrapping.cdict_struct_info(ti[13], ti)) == ok
+            @test !isnothing(JuliaLibWrapping.copt_struct_info(ti[14], ti)) == ok
+            @test JuliaLibWrapping.is_jlwstatus_struct(ti[16], ti) == ok
+            ok || continue
+            @test JuliaLibWrapping.cstring_struct_info(ti[7], ti).length_type == String(name)
+            @test JuliaLibWrapping.cstring_struct_info(ti[7], ti).length_bits == prim.bits
+            @test JuliaLibWrapping.carray_struct_info(ti[11], ti).dims_type == String(name)
+            @test JuliaLibWrapping.carray_struct_info(ti[11], ti).dims_bits == prim.bits
+            @test JuliaLibWrapping.cstrarray_struct_info(ti[12], ti).length_bits == prim.bits
+            @test JuliaLibWrapping.cdict_struct_info(ti[13], ti).length_bits == prim.bits
+            @test JuliaLibWrapping.copt_struct_info(ti[14], ti).has_value_bits == prim.bits
+        end
+    end
+
+    @testset "32-bit length guards" begin
+        typeinfo = OrderedDict{Int, TypeDesc}(
+            1 => PrimitiveTypeDesc("Int32", true, 32, 4, 4),
+            2 => PrimitiveTypeDesc("UInt8", false, 8, 1, 1),
+            3 => PrimitiveTypeDesc("Float64", false, 64, 8, 8),
+            4 => PointerDesc("Ptr{UInt8}", 2),
+            5 => PointerDesc("Ptr{Float64}", 3),
+            6 => StructDesc(
+                "CString{:borrowed}", 16, 8, FieldDesc[
+                    FieldDesc("length", 1, 0),
+                    FieldDesc("data", 4, 8),
+                ]
+            ),
+            7 => ArrayDesc("NTuple{1, Int32}", 1, 1, 4, 4),
+            8 => StructDesc(
+                "CVector{:borrowed, Float64}", 16, 8, FieldDesc[
+                    FieldDesc("dims", 7, 0),
+                    FieldDesc("data", 5, 8),
+                ]
+            ),
+            9 => PointerDesc("Ptr{CString{:borrowed}}", 6),
+            10 => StructDesc(
+                "CStrArray{:borrowed}", 16, 8, FieldDesc[
+                    FieldDesc("length", 1, 0),
+                    FieldDesc("data", 9, 8),
+                ]
+            ),
+        )
+        abi = ABIInfo(
+            typeinfo, BitSet(),
+            JuliaLibWrapping.MethodDesc[
+                JuliaLibWrapping.MethodDesc(
+                    "take_str", "take_str(s::CString{:borrowed})", 1,
+                    JuliaLibWrapping.ArgDesc[JuliaLibWrapping.ArgDesc("s", 6, false)]
+                ),
+            ]
+        )
+        mktempdir() do path
+            write_wrapper(PythonTarget(path, "narrow_demo", "libnarrow"), abi)
+            bindings = read(joinpath(path, "narrow_demo", "_lowlevel.py"), String)
+
+            @test occursin(
+                "        n = len(b)\n        if n > 0x7fffffff:\n" *
+                    "            raise OverflowError(f\"string length {n} exceeds " *
+                    "the library's 32-bit length field\")",
+                bindings
+            )
+            @test occursin("if any(d > 0x7fffffff for d in arr.shape):", bindings)
+            @test occursin(
+                "raise OverflowError(f\"array shape {arr.shape} exceeds " *
+                    "the library's 32-bit dims field\")",
+                bindings
+            )
+            @test occursin("dims=(ctypes.c_int32 * 1)(*arr.shape)", bindings)
+            @test occursin(
+                "        for b in bufs:\n            if len(b) > 0x7fffffff:",
+                bindings
+            )
+            @test occursin("if len(bufs) > 0x7fffffff:", bindings)
+
+            python3 = Sys.which("python3")
+            if python3 !== nothing
+                script = joinpath(path, "narrow_demo", "_lowlevel.py")
+                cmd = `$python3 -c "import ast; ast.parse(open('$script').read())"`
+                @test success(run(pipeline(cmd; stderr = devnull, stdout = devnull); wait = true))
+            elseif haskey(ENV, "CI")
+                error("python3 not found on PATH; required on CI to validate the emitted wrapper")
+            end
+        end
+
+        # 64-bit fields need no guard.
+        for golden in ("expected_cstring_lowlevel.py", "expected_cstrarray_lowlevel.py",
+                "expected_cmatrix_lowlevel.py")
+            @test !occursin("OverflowError", read(joinpath(@__DIR__, golden), String))
+        end
     end
 
     @testset "jlwstatus_location" begin
@@ -1704,7 +1863,7 @@ end
 
             # Borrowed classes construct values but do not release them.
             @test occursin("class CString_borrowed(ctypes.Structure):", bindings)
-            @test occursin("(\"length\", ctypes.c_int32)", bindings)
+            @test occursin("(\"length\", ctypes.c_int64)", bindings)
             @test occursin("(\"data\", ctypes.POINTER(ctypes.c_uint8))", bindings)
             @test occursin("def from_str(cls, s):", bindings)
             @test occursin("def from_bytes(cls, b):", bindings)
@@ -2296,7 +2455,7 @@ end
             # The struct class is emitted with the two-field layout and
             # decorated with the borrowed-flavored helpers.
             @test occursin("class CMatrix_borrowed_Float64(ctypes.Structure):", bindings)
-            @test occursin("(\"dims\", (ctypes.c_int32 * 2))", bindings)
+            @test occursin("(\"dims\", (ctypes.c_int64 * 2))", bindings)
             @test occursin("(\"data\", ctypes.POINTER(ctypes.c_double))", bindings)
             # Borrowed storage belongs to the caller: no ownership field, and
             # no `free()` to call on memory this side never allocated.
@@ -2309,7 +2468,7 @@ end
             @test occursin("if arr.ndim != 2:", bindings)
             @test occursin("if not arr.flags.f_contiguous:", bindings)
             @test occursin("expected_dtype = np.dtype(\"float64\")", bindings)
-            @test occursin("dims=(ctypes.c_int32 * 2)(*arr.shape)", bindings)
+            @test occursin("dims=(ctypes.c_int64 * 2)(*arr.shape)", bindings)
 
             # as_numpy returns a view with column-major strides.
             @test occursin("def as_numpy(self):", bindings)
@@ -2355,12 +2514,12 @@ end
             bindings = read(bindings_path, String)
 
             @test occursin("class CArray_borrowed_Float64_3(ctypes.Structure):", bindings)
-            @test occursin("(\"dims\", (ctypes.c_int32 * 3))", bindings)
+            @test occursin("(\"dims\", (ctypes.c_int64 * 3))", bindings)
             @test !occursin("owned", bindings)
             @test !occursin("def free(self):", bindings)
             @test occursin("if arr.ndim != 3:", bindings)
             @test occursin("if not arr.flags.f_contiguous:", bindings)
-            @test occursin("dims=(ctypes.c_int32 * 3)(*arr.shape)", bindings)
+            @test occursin("dims=(ctypes.c_int64 * 3)(*arr.shape)", bindings)
             @test occursin(
                 "np.ctypeslib.as_array(self.data, shape=tuple(self.dims)[::-1]).T",
                 bindings


### PR DESCRIPTION
Use Int64 for CArray dimensions and CString lengths. Recognize signed 32- and 64-bit carrier integer fields structurally, emit matching Python ctypes, and guard 32-bit conversions against overflow. Use Int for imported primitive layout metadata.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>