### PR TITLE
Support relative project source paths

### DIFF
--- a/JuliaLibWrapping/docs/src/concepts.md
+++ b/JuliaLibWrapping/docs/src/concepts.md
@@ -49,9 +49,10 @@ is driven through [JuliaC.jl](https://github.com/JuliaLang/JuliaC.jl)
 (a weak dependency): load it with `using JuliaC` before calling
 `build_library`.
 
-Relative `[sources]` paths in the entry project's `Project.toml` are
-rejected up front, because `juliac` relocates the project into a
-temporary directory before compiling.
+`build_library` supports relative `[sources]` paths, including paths in
+manifests for developed dependencies. It compiles from a temporary copy
+with absolute paths because `juliac` relocates the project before
+compiling. The original project is unchanged.
 
 ## The ABI data model
 

--- a/JuliaLibWrapping/docs/src/tutorial.md
+++ b/JuliaLibWrapping/docs/src/tutorial.md
@@ -93,10 +93,10 @@ Requirements:
 - ABI export requires Julia 1.13 or later.
 
 - The `[deps]` here describe what must be baked into `ols.so`. Keep it minimal,
-  without build tooling or test dependencies. If you need a `[sources]` entry to
-  point at a local checkout, use an absolute path: `juliac` relocates the
-  project into a temporary directory before compiling, so relative `[sources]`
-  paths cannot be resolved, and [`build_library`](@ref) rejects them.
+  without build tooling or test dependencies. `[sources]` entries may use
+  relative paths, such as `path = ".."` when this project is a subdirectory of
+  the package it wraps. [`build_library`](@ref) handles `juliac`'s project
+  relocation without modifying the original project.
 
 ## 3. Build the library and Python package
 

--- a/JuliaLibWrapping/examples/boundary/build.jl
+++ b/JuliaLibWrapping/examples/boundary/build.jl
@@ -19,10 +19,9 @@
 # on JuliaC.jl — without it, `build_library` errors with a hint.
 #
 # The extra machinery below exists only because we are dogfooding against
-# the in-tree `JLWInterop/` checkout: `juliac` requires `[sources]` paths
-# in the entry project to be absolute, so we materialize a transient copy
-# of `Project.toml` with `[sources]` injected. Once `JLWInterop` is
-# registered, the `prepare_project` step disappears too.
+# the in-tree `JLWInterop/` checkout: `prepare_project` adds its path to a
+# temporary copy of `Project.toml`.
+# Once `JLWInterop` is registered, the `prepare_project` step disappears too.
 
 using TOML: TOML
 

--- a/JuliaLibWrapping/examples/ols/build.jl
+++ b/JuliaLibWrapping/examples/ols/build.jl
@@ -19,10 +19,9 @@
 # on JuliaC.jl — without it, `build_library` errors with a hint.
 #
 # The extra machinery below exists only because we are dogfooding against
-# the in-tree `JLWInterop/` checkout: `juliac` requires `[sources]` paths
-# in the entry project to be absolute, so we materialize a transient copy
-# of `Project.toml` with `[sources]` injected. Once `JLWInterop` is
-# registered, the `prepare_project` step disappears too.
+# the in-tree `JLWInterop/` checkout: `prepare_project` adds its path to a
+# temporary copy of `Project.toml`.
+# Once `JLWInterop` is registered, the `prepare_project` step disappears too.
 
 using TOML: TOML
 

--- a/JuliaLibWrapping/src/build.jl
+++ b/JuliaLibWrapping/src/build.jl
@@ -48,12 +48,12 @@ function. `backend = :auto` (the default) and `backend = :juliac` are
 synonyms; the keyword is retained so additional backends can be added
 without changing the calling interface.
 
-# `[sources]` paths must be absolute
+# Relative `[sources]` paths
 
-`juliac` relocates the project into a temporary directory before compiling.
-Relative `[sources]` paths in the entry project's `Project.toml` cannot be
-resolved from there, so this function rejects them up front. Either use
-absolute paths or `Pkg.develop` the dependency.
+`build_library` supports relative `[sources]` paths and relative paths for
+developed dependencies in a manifest. Because `juliac` relocates the project,
+compilation uses a temporary copy with those paths made absolute. The original
+project is unchanged. Paths must refer to existing files or directories.
 
 # Bundling
 
@@ -127,7 +127,7 @@ function build_library(entry::AbstractString,
         end
     end
 
-    _validate_sources_absolute(project)
+    project = _materialize_project(project)
 
     mkpath(libdir)
     library_path = joinpath(libdir, libname * "." * Libdl.dlext)
@@ -218,9 +218,8 @@ The kwargs `out`, `entry`, `python_package`, `project`, `bundle`, and
 `build_library` (e.g. `verbose`, `trim`, `privatize`). `project`
 defaults to `dir`, but can be pointed at a separate location when the
 on-disk source layout and the entry `Project.toml` live in different
-directories (e.g. a transient project materialized with absolute
-`[sources]` paths for `juliac`). `version` sets the version in the generated
-Python package's `pyproject.toml` (see [`PythonTarget`](@ref)). For layouts
+directories. `version` sets the version in the generated Python
+package's `pyproject.toml` (see [`PythonTarget`](@ref)). For layouts
 outside this convention, call `build_library` directly.
 """
 function standard_build(dir::AbstractString = pwd();
@@ -243,24 +242,71 @@ function standard_build(dir::AbstractString = pwd();
                          kwargs...)
 end
 
-function _validate_sources_absolute(project::AbstractString)
+const _MANIFEST_FILE = r"^Manifest(-v\d+\.\d+)?\.toml$"
+
+# Return the original project if its source paths are absolute. Otherwise,
+# copy it and make relative Project and Manifest paths absolute for juliac.
+# Copy the whole directory because package sources and preferences may be used.
+function _materialize_project(project::AbstractString)
     pf = joinpath(project, "Project.toml")
-    isfile(pf) || return  # nothing to validate
+    isfile(pf) || return String(project)
     toml = TOML.parsefile(pf)
-    haskey(toml, "sources") || return
-    sources = toml["sources"]
-    sources isa AbstractDict || return
+    _absolutize_sources!(toml, project, pf) || return String(project)
+    dir = mktempdir()
+    for f in readdir(project)
+        src = joinpath(project, f)
+        if f == "Project.toml"
+            _write_toml(joinpath(dir, f), toml)
+        elseif occursin(_MANIFEST_FILE, f)
+            manifest = TOML.parsefile(src)
+            _absolutize_manifest!(manifest, project, src)
+            _write_toml(joinpath(dir, f), manifest)
+        else
+            cp(src, joinpath(dir, f))
+        end
+    end
+    return dir
+end
+
+# TOML formatting is irrelevant in this temporary project.
+function _write_toml(path::AbstractString, data::AbstractDict)
+    open(path, "w") do io
+        TOML.print(io, data; sorted = true)
+    end
+    return path
+end
+
+# Make a dependency's relative `path` absolute. Return whether it changed.
+function _absolutize_path!(spec, name, base::AbstractString, file::AbstractString)
+    spec isa AbstractDict || return false
+    p = get(spec, "path", nothing)
+    (p isa AbstractString && !isabspath(p)) || return false
+    abs = abspath(joinpath(base, p))
+    ispath(abs) || throw(ArgumentError(
+        "dependency \"$name\" in $file declares path \"$p\", " *
+        "which resolves to $abs — nothing exists there."))
+    spec["path"] = abs
+    return true
+end
+
+function _absolutize_sources!(toml, base, file)
+    sources = get(toml, "sources", nothing)
+    sources isa AbstractDict || return false
+    rewrote = false
     for (name, spec) in sources
-        spec isa AbstractDict || continue
-        haskey(spec, "path") || continue
-        p = spec["path"]
-        if !isabspath(p)
-            throw(ArgumentError(
-                """[sources] entry "$name" has relative path "$p" in $pf.
-                juliac copies the project into a temporary directory before compiling,
-                so relative [sources] paths cannot be resolved. Use an absolute path
-                (e.g. `path = $(repr(abspath(joinpath(project, p))))`) or `Pkg.develop`
-                the dependency."""))
+        rewrote |= _absolutize_path!(spec, name, base, file)
+    end
+    return rewrote
+end
+
+# Manifest dependencies are arrays of tables under `[deps]`.
+function _absolutize_manifest!(manifest, base, file)
+    deps = get(manifest, "deps", nothing)
+    deps isa AbstractDict || return
+    for (name, specs) in deps
+        specs isa AbstractVector || continue
+        for spec in specs
+            _absolutize_path!(spec, name, base, file)
         end
     end
     return

--- a/JuliaLibWrapping/test/test_build_library.jl
+++ b/JuliaLibWrapping/test/test_build_library.jl
@@ -5,8 +5,7 @@ using JuliaC
 using Test
 using TOML: TOML
 
-# `juliac` requires every `[sources]` path in the entry project to be
-# absolute, and the examples deliberately ship without one so their
+# The examples deliberately ship without a `[sources]` entry so their
 # `Project.toml` carries no machine-specific path. Materialize a transient
 # project that points `JLWInterop` at the in-tree checkout.
 function example_project(exdir)
@@ -25,50 +24,126 @@ function example_project(exdir)
 end
 
 @testset "build_library" begin
-    @testset "validate [sources] paths" begin
-        mktempdir() do proj
-            open(joinpath(proj, "Project.toml"), "w") do io
-                write(io, """
-                name = "Dummy"
-                uuid = "00000000-0000-0000-0000-000000000000"
+    @testset "materialize [sources] paths" begin
+        materialize = JuliaLibWrapping._materialize_project
 
-                [sources]
-                Foo = {path = "../foo"}
-                """)
-            end
-            entry = joinpath(proj, "src.jl")
-            touch(entry)
-            err = try
-                build_library(entry, AbstractTarget[]; project = proj, libname = "x")
-                nothing
-            catch e
-                e
-            end
-            @test err isa ArgumentError
-            @test occursin("relative path", err.msg)
-            @test occursin("Foo", err.msg)
+        # Rewrite relative paths while preserving other entries.
+        mktempdir() do root
+            mkpath(joinpath(root, "foo"))
+            proj = joinpath(root, "proj")
+            mkpath(joinpath(proj, "src"))
+            write(joinpath(proj, "src", "dummy.jl"), "module Dummy end\n")
+            pf = joinpath(proj, "Project.toml")
+            write(pf, """
+            name = "Dummy"
+            uuid = "00000000-0000-0000-0000-000000000000"
+            version = "1.2.3"
+
+            [deps]
+            Foo = "00000000-0000-0000-0000-0000000000f0"
+
+            [compat]
+            Foo = "0.1"
+
+            [sources]
+            Foo = {path = "../foo"}
+            Bar = {path = "/somewhere/bar"}
+            Baz = {url = "https://example.com/Baz.jl", rev = "main"}
+            """)
+            before = read(pf)
+
+            dir = materialize(proj)
+            @test dir != proj
+            toml = TOML.parsefile(joinpath(dir, "Project.toml"))
+            @test toml["sources"]["Foo"]["path"] == abspath(joinpath(root, "foo"))
+            @test toml["sources"]["Bar"]["path"] == "/somewhere/bar"
+            @test toml["sources"]["Baz"] == Dict("url" => "https://example.com/Baz.jl",
+                                                 "rev" => "main")
+            @test toml["name"] == "Dummy"
+            @test toml["uuid"] == "00000000-0000-0000-0000-000000000000"
+            @test toml["version"] == "1.2.3"
+            @test toml["deps"] == Dict("Foo" => "00000000-0000-0000-0000-0000000000f0")
+            @test toml["compat"] == Dict("Foo" => "0.1")
+
+            # Copy package sources along with the TOML files.
+            @test read(joinpath(dir, "src", "dummy.jl"), String) == "module Dummy end\n"
+
+            # The original is untouched.
+            @test read(pf) == before
         end
 
-        # Absolute paths are accepted.
-        mktempdir() do proj
-            open(joinpath(proj, "Project.toml"), "w") do io
-                write(io, """
-                name = "Dummy"
-                uuid = "00000000-0000-0000-0000-000000000001"
+        # Rewrite developed-dependency paths in versioned and plain manifests.
+        mktempdir() do root
+            mkpath(joinpath(root, "foo"))
+            proj = joinpath(root, "proj")
+            mkpath(proj)
+            write(joinpath(proj, "Project.toml"), """
+            [sources]
+            Foo = {path = "../foo"}
+            """)
+            mf = joinpath(proj, "Manifest.toml")
+            write(mf, """
+            julia_version = "1.13.0"
+            manifest_format = "2.0"
 
-                [sources]
-                Foo = {path = "/tmp/foo"}
-                """)
+            [[deps.Foo]]
+            path = "../foo"
+            uuid = "00000000-0000-0000-0000-0000000000f0"
+            version = "0.1.0"
+
+            [[deps.Bar]]
+            path = "/somewhere/bar"
+            uuid = "00000000-0000-0000-0000-0000000000ba"
+            version = "0.2.0"
+            """)
+            mf113 = joinpath(proj, "Manifest-v1.13.toml")
+            cp(mf, mf113)
+            before, before113 = read(mf), read(mf113)
+
+            dir = materialize(proj)
+            for name in ("Manifest.toml", "Manifest-v1.13.toml")
+                manifest = TOML.parsefile(joinpath(dir, name))
+                @test manifest["manifest_format"] == "2.0"
+                @test only(manifest["deps"]["Foo"])["path"] == abspath(joinpath(root, "foo"))
+                @test only(manifest["deps"]["Bar"])["path"] == "/somewhere/bar"
+                @test only(manifest["deps"]["Foo"])["version"] == "0.1.0"
             end
-            @test JuliaLibWrapping._validate_sources_absolute(proj) === nothing
+            @test read(mf) == before
+            @test read(mf113) == before113
         end
 
-        # No [sources] table at all is fine.
+        # Errors identify missing paths and their entries.
         mktempdir() do proj
-            open(joinpath(proj, "Project.toml"), "w") do io
-                write(io, "name = \"Dummy\"\nuuid = \"00000000-0000-0000-0000-000000000002\"\n")
-            end
-            @test JuliaLibWrapping._validate_sources_absolute(proj) === nothing
+            write(joinpath(proj, "Project.toml"), """
+            [sources]
+            Foo = {path = "../nowhere"}
+            """)
+            @test_throws "\"Foo\"" materialize(proj)
+            @test_throws "../nowhere" materialize(proj)
+            @test_throws abspath(joinpath(proj, "..", "nowhere")) materialize(proj)
+        end
+
+        # Use the original project when no paths need rewriting.
+        mktempdir() do proj
+            pf = joinpath(proj, "Project.toml")
+            write(pf, """
+            name = "Dummy"
+            uuid = "00000000-0000-0000-0000-000000000001"
+
+            [sources]
+            Foo = {path = "/somewhere/foo"}
+            """)
+            @test materialize(proj) == proj
+        end
+
+        mktempdir() do proj
+            write(joinpath(proj, "Project.toml"),
+                  "name = \"Dummy\"\nuuid = \"00000000-0000-0000-0000-000000000002\"\n")
+            @test materialize(proj) == proj
+        end
+
+        mktempdir() do proj
+            @test materialize(proj) == proj
         end
     end
 


### PR DESCRIPTION
Materialize a temporary project with absolute Project and Manifest paths when juliac relocation would change their meaning.

See #74.
