### PR TITLE
Use dense ABI array interfaces

### DIFF
--- a/JLWInterop/Project.toml
+++ b/JLWInterop/Project.toml
@@ -4,12 +4,14 @@ authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
 version = "0.2.0"
 
 [compat]
+LinearAlgebra = "1.10"
 OffsetArrays = "1.12"
 julia = "1.10"
 
 [extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OffsetArrays", "Test"]
+test = ["OffsetArrays", "Test", "LinearAlgebra"]

--- a/JLWInterop/src/JLWInterop.jl
+++ b/JLWInterop/src/JLWInterop.jl
@@ -56,10 +56,13 @@ end
 
 # Extended help
 
-`T` should be an `isbits` type. `CArray` implements the `AbstractArray`
-interface with linear indexing, including bounds-checked access and mutation.
-The aliases [`CVector`](@ref) and [`CMatrix`](@ref) cover one and two
-dimensions.
+`T` should be an `isbits` type. `CArray <: DenseArray` and supports linear
+indexing, the strided-array interface, and conversion to `Ptr{T}`. The aliases
+[`CVector`](@ref) and [`CMatrix`](@ref) cover one and two dimensions.
+
+`GC.@preserve` on a carrier protects nothing: the buffer is not
+garbage-collected memory. An owned buffer is valid until it is released; a
+borrowed one is valid for as long as its true owner keeps it so.
 
 Every construction path names an ownership: there is no defaulting
 constructor, and any parameter other than `:owned` or `:borrowed` is
@@ -70,7 +73,7 @@ changing the ABI. They must preserve column-major dimension and stride
 semantics. The two ownerships are two distinct types, so a target reads
 "release this" or "do not release this" off the signature alone.
 """
-struct CArray{owned, T, N} <: AbstractArray{T, N}
+struct CArray{owned, T, N} <: DenseArray{T, N}
     dims::NTuple{N, Int64}
     data::Ptr{T}
 
@@ -189,6 +192,15 @@ Base.@propagate_inbounds function Base.setindex!(a::CArray{owned, T}, x, i::Int)
     unsafe_store!(a.data, convert(T, x), i)
     return a
 end
+
+# `strides` and `pointer` use the `DenseArray` fallbacks.
+Base.unsafe_convert(::Type{Ptr{T}}, a::CArray{owned, T}) where {owned, T} = a.data
+Base.elsize(::Type{<:CArray{owned, T}}) where {owned, T} = sizeof(T)
+
+# Distinct carriers may wrap the same buffer.
+Base.dataids(a::CArray) = (UInt(a.data),)
+Base.mightalias(A::CArray, B::CArray) = !isdisjoint(Base.dataids(A), Base.dataids(B))
+Base.unaliascopy(a::CArray) = copy(a)
 
 """
     CString{owned}
@@ -371,6 +383,10 @@ Elements share the container's ownership — `data` points to `CString{owned}`s
 There is no default ownership or constructor that borrows a `Vector{String}`;
 borrowed carriers arrive across the ABI.
 
+`CStrArray{owned} <: AbstractVector{CString{owned}}` and is read-only.
+Collected elements still alias the carrier's buffers, which must be released
+only through the original carrier.
+
 # Example
 
 ```julia
@@ -378,10 +394,11 @@ using JLWInterop
 
 a = CStrArray{:owned}(["hello", "world"])
 Vector{String}(a) == ["hello", "world"]
+String.(a) == ["hello", "world"]
 JLWInterop._free_strings(a.data, a.length)
 ```
 """
-struct CStrArray{owned}
+struct CStrArray{owned} <: AbstractVector{CString{owned}}
     length::Int64
     data::Ptr{CString{owned}}     # each element a length-prefixed CString
 
@@ -394,6 +411,16 @@ struct CStrArray{owned}
         return new{owned}(length, data)
     end
 end
+
+Base.size(a::CStrArray) = (Int(a.length),)
+Base.IndexStyle(::Type{<:CStrArray}) = IndexLinear()
+
+Base.@propagate_inbounds function Base.getindex(a::CStrArray, i::Int)
+    @boundscheck checkbounds(a, i)
+    return unsafe_load(a.data, i)
+end
+
+# Replacing an owned descriptor would leak its buffer, so no `setindex!` is defined.
 
 # Copy without freeing the source.
 function Base.Vector{String}(a::CStrArray)

--- a/JLWInterop/src/api.jl
+++ b/JLWInterop/src/api.jl
@@ -95,6 +95,11 @@ The C-ABI argument carrier for `T`, or `nothing` when no mapping exists.
 Storage-backed argument carriers are borrowed. Dictionary values, optional
 payloads, and array elements must be concrete scalar bits types.
 
+`Array{T,N}` and `StridedArray{T,N}` arguments use the same borrowed `CArray`
+carrier. An `Array` argument receives an `unsafe_wrap`ped view; resizing it
+detaches it from the carrier's buffer. A `StridedArray` argument receives the
+carrier directly.
+
 A `Ptr{T}` is its own carrier and crosses unconverted: neither a length nor
 an owner travels with it. An argument addresses memory the caller owns. A
 return must address memory that outlives the call and that the caller can
@@ -122,6 +127,8 @@ carrier_type(::Type{Union{T, Nothing}}) where {T <: _API_SCALARS} =
     isconcretetype(T) ? COpt{T} : nothing
 carrier_type(::Type{<:Array{T, N}}) where {T <: _API_SCALARS, N} =
     isconcretetype(T) ? CArray{:borrowed, T, N} : nothing
+carrier_type(::Type{StridedArray{T, N}}) where {T <: _API_SCALARS, N} =
+    isconcretetype(T) ? CArray{:borrowed, T, N} : nothing
 carrier_type(::Type) = nothing
 
 """
@@ -135,6 +142,8 @@ carrier_return_type(::Type{Vector{String}}) = CStrArray{:owned}
 carrier_return_type(::Type{Dict{String, V}}) where {V <: _API_SCALARS} =
     isconcretetype(V) ? CDict{:owned, V} : nothing
 carrier_return_type(::Type{<:Array{T, N}}) where {T <: _API_SCALARS, N} =
+    isconcretetype(T) ? CArray{:owned, T, N} : nothing
+carrier_return_type(::Type{StridedArray{T, N}}) where {T <: _API_SCALARS, N} =
     isconcretetype(T) ? CArray{:owned, T, N} : nothing
 carrier_return_type(::Type{T}) where {T} = carrier_type(T)
 
@@ -200,7 +209,8 @@ from_carrier(::Type{String}, c::CString) = String(c)
 from_carrier(::Type{Vector{String}}, c::CStrArray) = Vector{String}(c)
 from_carrier(::Type{Dict{String, V}}, c::CDict{owned, V}) where {owned, V} = Dict{String, V}(c)
 from_carrier(::Type{A}, c::CArray{owned, T, N}) where {owned, T, N, A <: Array{T, N}} =
-    unsafe_wrap(Array, c.data, Int.(Tuple(c.dims)); own = false)   # zero-copy view
+    unsafe_wrap(Array, c.data, Int.(Tuple(c.dims)); own = false)
+from_carrier(::Type{StridedArray{T, N}}, c::CArray{:borrowed, T, N}) where {T, N} = c
 from_carrier(::Type{Union{T, Nothing}}, c::COpt{T}) where {T} = unwrap(c)
 
 # --- @api ----------------------------------------------------------------

--- a/JLWInterop/test/runtests.jl
+++ b/JLWInterop/test/runtests.jl
@@ -1,4 +1,5 @@
 using JLWInterop
+using LinearAlgebra
 using OffsetArrays
 using Test
 
@@ -271,6 +272,74 @@ using Test
         end
     end
 
+    @testset "CArray strided interface" begin
+        # A CArray is a contiguous, column-major StridedArray.
+        @test CArray{:borrowed, Float64, 2} <: DenseArray{Float64, 2}
+        @test CMatrix{:owned, Float64} <: StridedMatrix{Float64}
+        @test CVector{:borrowed, Float64} <: StridedVector{Float64}
+
+        A = [1.0 2.0; 3.0 4.0; 5.0 6.0]
+        GC.@preserve A begin
+            c = CArray{:borrowed}(A)
+            @test strides(c) === (1, 3)
+            @test Base.elsize(typeof(c)) === sizeof(Float64)
+            @test Base.unsafe_convert(Ptr{Float64}, c) === pointer(A)
+            @test pointer(c) === pointer(A)
+            @test pointer(c, 4) === pointer(A, 4)
+
+            # A ccall expecting Ptr{T} accepts the carrier.
+            dest = zeros(6)
+            GC.@preserve dest begin
+                cdest = CArray{:borrowed}(dest)
+                ccall(
+                    :memcpy, Ptr{Cvoid}, (Ptr{Float64}, Ptr{Float64}, Csize_t),
+                    cdest, c, 6 * sizeof(Float64)
+                )
+            end
+            @test dest == vec(A)
+        end
+
+        # BLAS operates on the buffers in place.
+        B, C, D = rand(4, 3), rand(3, 5), zeros(4, 5)
+        GC.@preserve B C D begin
+            mul!(CArray{:borrowed}(D), CArray{:borrowed}(B), CArray{:borrowed}(C))
+            @test D ≈ B * C
+        end
+        v = rand(8)
+        GC.@preserve v begin
+            cv = CArray{:borrowed}(v)
+            @test dot(cv, cv) ≈ dot(v, v)
+        end
+
+        # The all-zero error-path carrier is a well-formed empty array.
+        z = JLWInterop._zero_carrier(CArray{:owned, Float64, 2})
+        @test size(z) == (0, 0)
+        @test strides(z) === (1, 0)
+        @test isempty(collect(z))
+        @test sum(z) === 0.0
+    end
+
+    @testset "CArray aliasing" begin
+        # Aliasing is keyed on the data pointer rather than carrier identity.
+        v = collect(1.0:6.0)
+        other = zeros(6)
+        GC.@preserve v other begin
+            c6 = CArray{:borrowed}(v)
+            c23 = CMatrix{:borrowed, Float64}(2, 3, pointer(v))
+            cother = CArray{:borrowed}(other)
+
+            @test Base.dataids(c6) === (UInt(pointer(v)),)
+            @test Base.mightalias(c6, c23)
+            @test !Base.mightalias(c6, cother)
+
+            # `unalias` copies a detected alias.
+            u = Base.unalias(c23, c6)
+            @test u isa Vector{Float64}
+            @test u == v
+            @test Base.unalias(cother, c6) === c6
+        end
+    end
+
     @testset "CArray layout" begin
         # C and Python emitters rely on this field layout.
         @test fieldnames(CArray) == (:dims, :data)
@@ -410,7 +479,18 @@ using Test
             @test m isa CMatrix{:borrowed, Float64}
             @test m.dims === (Int64(2), Int64(2))
             @test collect(m) == M
+
+            # Re-borrowing a carrier returns the same descriptor.
+            @test CArray{:borrowed}(m) === m
         end
+
+        # Borrowing an owned carrier aliases without transferring ownership.
+        o = CArray{:owned}([1.0, 2.0])
+        b = CArray{:borrowed}(o)
+        @test b isa CVector{:borrowed, Float64}
+        @test b.data === o.data
+        @test b.dims === o.dims
+        Libc.free(o.data)
 
         # Non-`DenseArray` storage cannot be aliased safely, even when it
         # happens to be contiguous: the layout guarantee lives in the type.
@@ -514,6 +594,33 @@ using Test
         borrowed = CStrArray{:borrowed}(a2.length, a2.data)
         @test Vector{String}(borrowed) == ["p", "q"]
         JLWInterop._free_strings(a2.data, a2.length)
+    end
+
+    @testset "CStrArray AbstractVector interface" begin
+        a = CStrArray{:owned}(["hello", "wörld", ""])
+        @test a isa AbstractVector{CString{:owned}}
+        @test IndexStyle(typeof(a)) === IndexLinear()
+        @test size(a) == (3,)
+        @test length(a) == 3
+        @test eltype(a) === CString{:owned}
+
+        # Indexing and iteration yield the descriptors in place.
+        @test a[1] isa CString{:owned}
+        @test String(a[2]) == "wörld"
+        @test String.(a) == ["hello", "wörld", ""]
+        @test map(ncodeunits, a) == [5, 6, 0]
+        @test_throws BoundsError a[0]
+        @test_throws BoundsError a[4]
+
+        # Read-only: replacing a descriptor would leak the buffer it points to.
+        @test_throws CanonicalIndexError a[1] = a[2]
+
+        # `collect` copies descriptors, not buffers, so the elements alias.
+        descs = collect(a)
+        @test descs isa Vector{CString{:owned}}
+        @test descs[1].data === a[1].data
+
+        JLWInterop._free_strings(a.data, a.length)
     end
 
     @testset "CDict layout" begin
@@ -1489,6 +1596,65 @@ using Test
         st = Core.eval(m, :(ApiCall_outside(1))).status
         @test status_message(st) == "DomainError"
         @test st.code == JLWInterop._API_ERROR_CODES.generic
+    end
+
+    @testset "@api StridedArray arguments receive the carrier" begin
+        # A StridedArray argument receives the CArray carrier directly.
+        @test JLWInterop.carrier_type(StridedArray{Float64, 2}) === CArray{:borrowed, Float64, 2}
+        @test JLWInterop.carrier_type(StridedVector{Int32}) === CArray{:borrowed, Int32, 1}
+        @test JLWInterop.carrier_return_type(StridedArray{Float64, 1}) === CArray{:owned, Float64, 1}
+        # Only supported concrete scalars have a fixed ABI.
+        @test JLWInterop.carrier_type(StridedArray{Real, 2}) === nothing
+        @test JLWInterop.carrier_type(StridedArray{String, 1}) === nothing
+
+        c = CArray{:borrowed, Float64, 1}((Int64(2),), Ptr{Float64}(0))
+        @test JLWInterop.from_carrier(StridedArray{Float64, 1}, c) === c
+
+        m = Module(:ApiStrided)
+        Core.eval(m, :(using JLWInterop))
+        Core.eval(
+            m, quote
+                function colsum(A::StridedArray{Float64, 2})
+                    A isa CMatrix{:borrowed, Float64} ||
+                        error("expected the carrier, got " * string(typeof(A)))
+                    vec(sum(A; dims = 1))
+                end
+            end
+        )
+        Core.eval(
+            m, :(
+                JLWInterop.@api colsum(A::StridedArray{Float64, 2})::StridedArray{Float64, 1}
+            )
+        )
+        Core.eval(
+            m, quote
+                function dbl(A::StridedArray{Float64, 1})
+                    A .*= 2.0
+                    nothing
+                end
+            end
+        )
+        Core.eval(
+            m, :(
+                JLWInterop.@api dbl(A::StridedArray{Float64, 1})::Nothing
+            )
+        )
+
+        # The declared return is copied into an owned carrier.
+        A = [1.0 2.0; 3.0 4.0]
+        r = GC.@preserve A Core.eval(m, :(ApiStrided_colsum($(CArray{:borrowed}(A)))))
+        @test iszero(r.status.code)
+        @test r.value isa CVector{:owned, Float64}
+        @test unsafe_load(r.value.data, 1) == 4.0
+        @test unsafe_load(r.value.data, 2) == 6.0
+        Libc.free(r.value.data)
+
+        # Mutation through the carrier reaches the caller's buffer.
+        v = [1.0, 2.0, 3.0]
+        st = GC.@preserve v Core.eval(m, :(ApiStrided_dbl($(CArray{:borrowed}(v)))))
+        @test st isa JLWStatus
+        @test iszero(st.code)
+        @test v == [2.0, 4.0, 6.0]
     end
 
     @testset "@api raw pointers and library-registered carriers" begin


### PR DESCRIPTION
- make CArray a DenseArray with pointer and aliasing support
- expose CStrArray as a read-only AbstractVector
- accept StridedArray arguments and returns in @api

Assisted-by: Claude Fable 5 <noreply@anthropic.com>