### PR TITLE
Deploy versioned docs for prefixed release tags

### DIFF
--- a/JuliaLibWrapping/docs/make.jl
+++ b/JuliaLibWrapping/docs/make.jl
@@ -28,4 +28,8 @@ makedocs(;
 deploydocs(;
     repo = "github.com/JuliaInterop/JuliaLibWrapping.jl",
     devbranch = "main",
+    # TagBot tags releases of this subdir package as JuliaLibWrapping-vX.Y.Z;
+    # without the prefix, deploydocs skips tag builds and never deploys
+    # versioned (stable) docs.
+    tag_prefix = "JuliaLibWrapping-",
 )


### PR DESCRIPTION
The [stable docs page](https://juliainterop.github.io/JuliaLibWrapping.jl/stable/) has never been populated despite several releases: gh-pages contains only `dev/`. The cause is that TagBot tags releases of this subdir package as `JuliaLibWrapping-vX.Y.Z`, while `deploydocs` by default only treats plain `vX.Y.Z` tags as release builds — so the docs job ran on every tag push but skipped deployment. Passing `tag_prefix = "JuliaLibWrapping-"` (Documenter ≥ 1.2) makes `deploydocs` recognize the prefixed tags.

Note this takes effect with the next release tag; re-running the existing tag workflows would rebuild from the tagged commits, which lack this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pcecGPpoytbbGbsPJ8LrY